### PR TITLE
Ab#disable mocks

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - NODE_OPTIONS=--max-old-space-size=8096
       - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - MOCKS=${MOCKS}
       - APP__PORT=8080
       - APP__ADMIN__EMAIL=${OPENCTI_ADMIN_EMAIL}
       - APP__ADMIN__PASSWORD=${OPENCTI_ADMIN_PASSWORD}

--- a/docker/env.example
+++ b/docker/env.example
@@ -15,4 +15,4 @@ OPENID_ISSUER=https://example.com/auth/realms/xxxx # URL
 OPENID_CLIENT_ID=ChangeMe # String
 OPENID_CLIENT_SECRET=ChangeMe # String
 REACT_APP_API_URL=https://44.236.83.168
-MOCK=1  # change to 0 to disable the use of mock data
+MOCKS=1  # change to 0 to disable the use of mock data

--- a/docker/env.example
+++ b/docker/env.example
@@ -14,3 +14,5 @@ SMTP_HOSTNAME=ChangeMe # String
 OPENID_ISSUER=https://example.com/auth/realms/xxxx # URL
 OPENID_CLIENT_ID=ChangeMe # String
 OPENID_CLIENT_SECRET=ChangeMe # String
+REACT_APP_API_URL=https://44.236.83.168
+MOCK=1  # change to 0 to disable the use of mock data

--- a/opencti-platform/opencti-graphql/src/cyio/schema/mocks.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/mocks.js
@@ -69,6 +69,13 @@ const mocks = {
     vendor_name: 'Apple',
     version: '11.6',
   }),
+  User: () => ({
+    id: null,
+  }),
+  Settings: () => ({
+    platform_theme_dark_primary: null,
+    platform_theme_dark_secondary: null,
+  }),
 };
 
 export default mocks ;

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -17,7 +17,7 @@ import { expandToken } from '../service/keycloak';
 // import { KeycloakContext, KeycloakTypeDefs, KeycloakSchemaDirectives } from 'keycloak-connect-graphql';
 
 // mocks
-import mocks from './mocks.js' ;
+import mockList from './mocks.js' ;
 
 
 const buildContext = (user, req, res) => {
@@ -32,6 +32,15 @@ const buildContext = (user, req, res) => {
 
 // perform the standard keycloak-connect middleware setup on our app
 // const { keycloak } = configureKeycloak(app, graphqlPath)  // Same ApolloServer initialization as before, plus the drain plugin.
+
+// check to see if mocks are disbled
+let mocks;
+if (process.env.MOCKS === '0') {
+  mocks = false;
+}
+else {
+  mocks = mockList;
+}
 
 const createApolloServer = () => {
   const cdnUrl = conf.get('app:playground_cdn_url');


### PR DESCRIPTION
This PR is to add support to the graphQL server to allow the use of mock data to be disabled.  This should help those involved in UI development that were having issues due to getting mock data for items where the UI expected a null value.