### PR TITLE
Add mutators to allow to delete one or multiple assets by Id

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/typeDefs.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/typeDefs.js
@@ -65,6 +65,8 @@ const typeDefs = gql`
   }
 
   extend type Mutation {
+    deleteAsset(id:ID!): ID
+    deleteAssets(id:[ID]!): [ID]
     createAssetLocation(input: AssetLocationAddInput): AssetLocation
     deleteAssetLocation(id: ID!): String!
     editAssetLocation(id: ID!, input: [EditInput]!, commitMessage: String): AssetLocation


### PR DESCRIPTION
This PR incorporates support for two new mutators for all types of assets:

- deleteAsset(id: ID!): ID - allows the deletion of any type of asset by its Id value
- deleteAssets( id: [ID]!): [ID] - allows the deletion of assets by their Id value

These were added to support the Asset line or card view's ability to multi-select assets to be deleted