### PR TITLE
AB#4452 Adding support for the fileId returned from S3 presign request

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
+++ b/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
@@ -28,6 +28,7 @@ import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
 import { createScan } from '../../../../services/scan.service';
 import { scanAxios } from '../../../../utils/axios';
+import updateFileName from "../../../../utils/s3FileName";
 import ReactS3Uploader from 'react-s3-uploader';
 import bsCustomFileInput from "bs-custom-file-input";
 import LinearProgress from '@material-ui/core/LinearProgress';
@@ -192,9 +193,11 @@ const VulnerabilityScan = (props) => {
 		props.onClose();
 	};
 
-	const onFinishUpload = (s3Url) => {
+	const onFinishUpload = (result) => {
+		const {fileId} = result;
 		const data = getValues();
 		data.file = data.scan_name;
+		data.fileId = fileId;
 		newScan(data).then(() => {
 			setUploadPercentage(0);
 			setIsLoading(false);
@@ -210,11 +213,6 @@ const VulnerabilityScan = (props) => {
 		setIsLoading(true);
 		setDisableSubmit(true);
 		fileRef.current.uploadFile();
-	};
-
-	const updateFileName = (filename) => {
-		const updatedFileName = filename;
-		return updatedFileName;
 	};
 
 	const preSignS3 = async (file, callback) => {

--- a/opencti-platform/opencti-front/src/services/scan.service.js
+++ b/opencti-platform/opencti-front/src/services/scan.service.js
@@ -5,7 +5,7 @@ import updateFileName from "../utils/s3FileName";
 
 export const createScan = async (params, clientID, passedConfig) => {
   const bodyParams = {
-    path: updateFileName(params.file),
+    path: updateFileName(params.fileId || params.file), // compatability for new file id over file name
     scan_name: params.scan_name,
     vulnerability_range: params.vulnerabilityRange,
     weakness_range: params.weaknessRange,


### PR DESCRIPTION
Adds support for the new field returned by the presign url request which now returns **fileId** as a uuid assigned for that file. It will be used when sending the POST request for creating the Scan in Arkon and using this still preserves the original file name but ensures that there are no conflicts with S3 object key naming conventions.