### PR TITLE
AB#4570 Removing the hover background for the bar charts.

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/vsac/ViewCharts.js
+++ b/opencti-platform/opencti-front/src/private/components/vsac/ViewCharts.js
@@ -481,7 +481,7 @@ class ViewCharts extends Component {
                             domain={[1999, 2021]}
                           />
                           <YAxis type="number" />
-                          <Tooltip />
+                          <Tooltip cursor={false}/>
                           <Legend />
                           <Bar
                             stackId="a"
@@ -538,7 +538,7 @@ class ViewCharts extends Component {
                           <CartesianGrid strokeDasharray="3 3" />
                           <XAxis type="number" domain={[0, 'auto']} />
                           <YAxis type="category" dataKey="host" />
-                          <Tooltip />
+                          <Tooltip cursor={false}/>
                           <Legend />
                           <Bar
                             stackId="a"
@@ -590,7 +590,7 @@ class ViewCharts extends Component {
                           <CartesianGrid strokeDasharray="3 3" />
                           <XAxis type="number" domain={[0, 'auto']} />
                           <YAxis type="category" dataKey="product" />
-                          <Tooltip />
+                          <Tooltip cursor={false}/>
                           <Legend />
                           <Bar
                             stackId="a"


### PR DESCRIPTION
The cursor prop of the Tooltip was causing the background. Note we can fill that with whatever color we wanted.