### PR TITLE
AB#4678 Login screen error

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.js
+++ b/opencti-platform/opencti-front/src/private/Root.js
@@ -9,6 +9,7 @@ import { ConnectedThemeProvider } from '../components/AppThemeProvider';
 import Index from './Index';
 import { UserContext } from '../utils/Security';
 import AuthBoundaryComponent from './components/AuthBoundary';
+import RootPublic from '../public/Root';
 
 const rootPrivateQuery = graphql`
   query RootPrivateQuery {
@@ -43,7 +44,14 @@ const Root = () => (
     <QueryRenderer
       query={rootPrivateQuery}
       variables={{}}
-      render={({ props }) => {
+      render={(data) => {
+        const { props } = data;
+        // Check in conjunction with query renderer. Rather than throwing an error for failed root query
+        // pass the empty data and do the login render here since query render can't do redirect or
+        // render stuff.
+        if(props === null ){
+          return <RootPublic/>
+        }
         clearToken();
         if (props) {
           if (props.me && props.me.access_token) {

--- a/opencti-platform/opencti-front/src/relay/environment.js
+++ b/opencti-platform/opencti-front/src/relay/environment.js
@@ -128,8 +128,15 @@ export class QueryRenderer extends Component {
           const types = error ? map((e) => e.name, error) : [];
           const unmanagedErrors = difference(types, managedErrorTypes || []);
           if (!isEmpty(unmanagedErrors)) {
-            toastGenericError('Query Error');
-            throw new ApplicationError(error);
+            // This is to fix the error that constantly comes up when the user is not authenticated
+            // when accessing the site. This is the first query to be run for any page so should be
+            // binary good or fail
+            if (query.operation.name === 'RootPrivateQuery') {
+              render(error);
+            } else {
+              toastGenericError('Query Error');
+              throw new ApplicationError(error);
+            }
           }
           return render(data);
         }}


### PR DESCRIPTION
There has been an issue for some time that is inherintly built into the way OpenCTI is designed. Essentially the root of any page queries the graphql server for information on the logged in user. However, this query will fail and force the login page to render which is not all that bad. However, for us to provide a better experience we need to not render these errors because OCTI is badly designed in that way. 

I changed up the render portion of the QueryRenderer and the private Root components. The solution is handling a special case while preserving the original so to prevent (hopefully) issues down the road.