### PR TITLE
AB#4671

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
@@ -265,8 +265,8 @@ const LeftBar = ({
             <MenuList component="nav" classes={{ root: classes.bottomNavigation }}>
             <MenuItem
               component={Link}
-              to="dashboard/profile"
-              selected={location.pathname.includes('dashboard/profile')}
+              to="/dashboard/profile"
+              selected={location.pathname.includes('/dashboard/profile')}
               dense={false}
               classes={{ root: classes.menuItem }}
             >


### PR DESCRIPTION
Simple fix for the profile button in the left nav. The path's were missing the leading root '/' so it was trying to navigate relatively.