### PR TITLE
fix: ensuring the user input for the scan name is applied when submit…

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
+++ b/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
@@ -168,27 +168,20 @@ const VulnerabilityScan = (props) => {
 
 	const STATUS_INTERVAL = 10000;
 
-	const [vulnerabilityRange, setVulnerabilityRange] = useState(
-		defaultVulnerabilityRange
-	);
-	const [weaknessCount, setWeaknessCount] = useState(defaultWeaknessCount);
-	const [vignette, setVignette] = useState(defaultVignette);
 	const [uploadPercentage, setUploadPercentage] = useState(0);
-	const [isLoading, setIsLoading] = useState(false);
 	const [currentOrg] = useState(localStorage.getItem('currentOrg'))
 	const [disableSubmit, setDisableSubmit] = useState(false)
-	const { onSubmit, client_ID } = props;
+	const { client_ID } = props;
 
-	const { register, handleSubmit, setValue, control, getValues, errors } = useForm();
+	const { register, handleSubmit, setValue, getValues } = useForm();
 
 	const { ref, ...inputProps } = register("file");
 
-	const scan_name = useRef();
 	const fileRef= useRef();
 
 	useEffect(() => {
     	bsCustomFileInput.init();
-  	});
+	});
 
 	const handleClose = () => {
 		props.onClose();
@@ -197,23 +190,21 @@ const VulnerabilityScan = (props) => {
 	const onFinishUpload = (result) => {
 		const {fileId} = result;
 		const data = getValues();
-		data.file = data.scan_name;
+		data.file = data.scanName;
 		data.fileId = fileId;
 		newScan(data).then(() => {
 			setUploadPercentage(0);
-			setIsLoading(false);
 			toastSuccess("Scan Uploaded")
 		});
 	};
 
 	const onErrorUpload = (error) => {
 		toastGenericError("Scan Upload Failed")
+		console.error(error)
 		setUploadPercentage(0);
-		setIsLoading(false);
 	};
 
 	const onFormSubmit = (data) => {
-		setIsLoading(true);
 		setDisableSubmit(true);
 		fileRef.current.uploadFile();
 	};
@@ -247,11 +238,11 @@ const VulnerabilityScan = (props) => {
 	const setUploadedFileName = (event) => {
 		const rawPath = event.target.value
 		if(!rawPath){
-			setValue("scan_name", null)
+			setValue("scanName", null)
 		}else{
-			let fileName = rawPath.substr(rawPath.lastIndexOf("\\") + 1)
+			let fileName = rawPath.substring(rawPath.lastIndexOf("\\") + 1)
 			if(fileName.length === 0) fileName = null
-			setValue("scan_name", fileName)
+			setValue("scanName", fileName)
 		}
 	};
 
@@ -274,7 +265,7 @@ const VulnerabilityScan = (props) => {
 	const newScan = async (data) => {
 		const params = {
 			file: data.fileId || data.file,
-			scan_name: getValues('scan_name'),
+			scan_name: getValues('scanName'),
 			vulnerabilityRange: getValues('vulnerability_ranges') || vulnerabilityRanges[0].id,
 			weaknessRange: getValues('weakness_count') || weaknessesCount[0].id,
 			vignette: getValues('weakness_score') || vignettes[0].id,
@@ -283,16 +274,15 @@ const VulnerabilityScan = (props) => {
 
 		try {
 			await createScan(params, client_ID);
-			 
 			setTimeout(() => {
 	        	props.rerenderParentCallback();
 	       		handleClose();
 	      	}, STATUS_INTERVAL);
 		} catch (error) {
-			//setIsPendingAnalysis(false);
-			console.log(error);
+			console.error(error);
 		}
 	};
+
 	return (
 		<Paper
 			classes={{ root: classes.paper }}
@@ -324,10 +314,10 @@ const VulnerabilityScan = (props) => {
 								<ReactS3Uploader
 									name="file"
 									ref={(ref) => {
-				                      fileRef.current = ref;
-				                    }}
-				                    inputRef={ref}
-				                    {...inputProps}
+										fileRef.current = ref;
+									}}
+									inputRef={ref}
+									{...inputProps}
 									className="custom-file-input"
 									getSignedUrl={preSignS3}
 									s3path="/uploads/"
@@ -350,10 +340,7 @@ const VulnerabilityScan = (props) => {
 								>
 									Choose the vulnerability scan file to upload
 								</label>
-								<Box color="text.secondary">
-				                  or drag and drop it here
-				                </Box>	
-
+								<Box color="text.secondary"> or drag and drop it here </Box>
 							</Box>
 							{uploadPercentage >= 1 ? (
 								<Box 
@@ -370,7 +357,7 @@ const VulnerabilityScan = (props) => {
 									label="Scan Name"
 									name="scan_name"
 									defaultValue="A custom scan file name"
-									inputRef={scan_name}
+									onChange={(event) => setValue("scanName", event.target.value)}
 								/>
 							</FormGroup>
 							<FormGroup row={true}>
@@ -380,10 +367,8 @@ const VulnerabilityScan = (props) => {
 											<Select
 												labelId="demo-simple-select-label"
 												id="demo-simple-select"
-												defaultValue={
-													vulnerabilityRanges[0].id
-												}
-												onChange={(event, value) => {
+												defaultValue={ vulnerabilityRanges[0].id }
+												onChange={(event) => {
 													handleVulnerabilityRanges(
 														event
 													);
@@ -397,8 +382,7 @@ const VulnerabilityScan = (props) => {
 															{item.title}
 														</MenuItem>
 													)
-												)}
-												;
+												)};
 											</Select>
 										</ListItemIcon>
 										<ListItemText
@@ -417,7 +401,7 @@ const VulnerabilityScan = (props) => {
 												defaultValue={
 													weaknessesCount[0].id
 												}
-												onChange={(event, value) => {
+												onChange={(event) => {
 													handleWeaknessCount(event);
 												}}
 											>
@@ -473,7 +457,7 @@ const VulnerabilityScan = (props) => {
 										<Checkbox
 											name="checkedB"
 											color="primary"
-											onChange={(event, value) => {
+											onChange={(event) => {
 												handleNotify(event);
 											}}
 										/>


### PR DESCRIPTION
Fixing a bug where the custom name for the scan was not being applied when entered. Removed the `useRef` stuff as there was not real purpose for it and instead saved the value in the form data `setValue`.