### PR TITLE
AB#4863 Feature Flagging

### DIFF
--- a/opencti-platform/opencti-front/src/app.js
+++ b/opencti-platform/opencti-front/src/app.js
@@ -8,9 +8,10 @@ import RedirectManager from './components/RedirectManager';
 import RootPrivate from './private/Root';
 import 'react-toastify/dist/ReactToastify.css';
 import './resources/css/toast-override.css';
+import FeatureProvider from './components/feature/FeatureProvider';
 
 const App = () => (
-  <div>
+  <FeatureProvider>
     <BrowserRouter basename={APP_BASE_PATH}>
       <RedirectManager>
         <Switch>
@@ -31,7 +32,7 @@ const App = () => (
       draggable={false}
       pauseOnHover
     />
-  </div>
+  </FeatureProvider>
 );
 
 export default App;

--- a/opencti-platform/opencti-front/src/components/feature/FeatureFlag.js
+++ b/opencti-platform/opencti-front/src/components/feature/FeatureFlag.js
@@ -1,6 +1,6 @@
-import {useContext} from "react";
-import PropTypes from "prop-types";
-import {FeatureContext} from "./FeatureProvider";
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { FeatureContext } from './FeatureProvider';
 
 /**
  * Should wrap components that can be disabled with a feature flag.
@@ -12,19 +12,19 @@ import {FeatureContext} from "./FeatureProvider";
  * @returns {*|JSX.Element}
  */
 const FeatureFlag = (props) => {
-  const featureContext = useContext(FeatureContext)
-  const {children, tag, alt} = props
-  const disabled = featureContext[tag] ?? false
-  return !disabled ? children : alt
-}
+  const featureContext = useContext(FeatureContext);
+  const { children, tag, alt } = props;
+  const disabled = featureContext[tag] ?? false;
+  return (disabled ? alt : children) ?? <></>;
+};
 
 FeatureFlag.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
+    PropTypes.node,
   ]).isRequired,
   alt: PropTypes.node,
-  tag: PropTypes.string
-}
+  tag: PropTypes.string.isRequired,
+};
 
-export default FeatureFlag
+export default FeatureFlag;

--- a/opencti-platform/opencti-front/src/components/feature/FeatureFlag.js
+++ b/opencti-platform/opencti-front/src/components/feature/FeatureFlag.js
@@ -1,0 +1,30 @@
+import {useContext} from "react";
+import PropTypes from "prop-types";
+import {FeatureContext} from "./FeatureProvider";
+
+/**
+ * Should wrap components that can be disabled with a feature flag.
+ *
+ * Usage:
+ *
+ * <FeatureFlag tag="VSAC"> ... </FeatureFlag>
+ *
+ * @returns {*|JSX.Element}
+ */
+const FeatureFlag = (props) => {
+  const featureContext = useContext(FeatureContext)
+  const {children, tag, alt} = props
+  const disabled = featureContext[tag] ?? false
+  return !disabled ? children : alt
+}
+
+FeatureFlag.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
+  alt: PropTypes.node,
+  tag: PropTypes.string
+}
+
+export default FeatureFlag

--- a/opencti-platform/opencti-front/src/components/feature/FeatureProvider.js
+++ b/opencti-platform/opencti-front/src/components/feature/FeatureProvider.js
@@ -1,0 +1,43 @@
+import {createContext} from "react";
+
+export const FeatureContext = createContext({})
+/**
+ * Component exposing the capability to conditionally render components depending on if they have been flagged to be disabled.
+ * This should wrap the entire application or at least the most root component where feature flagging is needed. (Whole app is best)
+ *
+ * Components that should be flagged for disabling need to be wrapped in a FeatureFlag component.
+ *
+ * Disable flagging of a feature is done with environment variables prefixed with REACT_APP_FEAT and disabled with 0.
+ *
+ * Example:
+ *
+ * REACT_APP_FEAT_VSAC = 0.
+ *
+ * with a <FeatureFlag tag="VSAC">,,,</FeatureFlag>
+ *
+ * Children of the flag will not render.
+ *
+ * @returns {JSX.Element}
+ */
+const FeatureProvider = (props) => {
+  const {children} = props
+
+  const envFeatMap = []
+  Object.keys(process.env)
+    .filter((k) => k.startsWith("REACT_APP_FEAT_"))
+    .map((k) => envFeatMap.push({env: k, feature: k.replace("REACT_APP_FEAT_", "")}))
+
+  const disableMap = {}
+  envFeatMap.forEach((m) => {
+    const varValue = process.env[m.env]
+    disableMap[m.feature] = varValue === "0"
+  })
+
+  return (
+    <FeatureContext.Provider value={disableMap}>
+      {children}
+    </FeatureContext.Provider>
+  )
+}
+
+export default FeatureProvider

--- a/opencti-platform/opencti-front/src/components/feature/FeatureProvider.js
+++ b/opencti-platform/opencti-front/src/components/feature/FeatureProvider.js
@@ -1,43 +1,47 @@
-import {createContext} from "react";
+import React, { createContext } from 'react';
 
-export const FeatureContext = createContext({})
+export const FeatureContext = createContext({});
 /**
- * Component exposing the capability to conditionally render components depending on if they have been flagged to be disabled.
- * This should wrap the entire application or at least the most root component where feature flagging is needed. (Whole app is best)
+ * Component exposing the capability to conditionally render components depending
+ * on if they have been flagged to be disabled.
+ * This should wrap the entire application or at least the most root component where
+ * feature flagging is needed.
+ * (Whole app is best)
  *
  * Components that should be flagged for disabling need to be wrapped in a FeatureFlag component.
  *
- * Disable flagging of a feature is done with environment variables prefixed with REACT_APP_FEAT and disabled with 0.
+ * Disable flagging of a feature is done with environment variables prefixed with REACT_APP_FEAT
+ * and disabled with 0.
  *
  * Example:
  *
  * REACT_APP_FEAT_VSAC = 0.
  *
- * with a <FeatureFlag tag="VSAC">,,,</FeatureFlag>
+ * with a <FeatureFlag tag="VSAC">...</FeatureFlag>
  *
  * Children of the flag will not render.
  *
  * @returns {JSX.Element}
  */
 const FeatureProvider = (props) => {
-  const {children} = props
+  const { children } = props;
 
-  const envFeatMap = []
+  const envFeatMap = [];
   Object.keys(process.env)
-    .filter((k) => k.startsWith("REACT_APP_FEAT_"))
-    .map((k) => envFeatMap.push({env: k, feature: k.replace("REACT_APP_FEAT_", "")}))
+    .filter((k) => k.startsWith('REACT_APP_FEAT_'))
+    .map((k) => envFeatMap.push({ env: k, feature: k.replace('REACT_APP_FEAT_', '') }));
 
-  const disableMap = {}
+  const disableMap = {};
   envFeatMap.forEach((m) => {
-    const varValue = process.env[m.env]
-    disableMap[m.feature] = varValue === "0"
-  })
+    const varValue = process.env[m.env];
+    disableMap[m.feature] = varValue === '0';
+  });
 
   return (
     <FeatureContext.Provider value={disableMap}>
       {children}
     </FeatureContext.Provider>
-  )
-}
+  );
+};
 
-export default FeatureProvider
+export default FeatureProvider;

--- a/opencti-platform/opencti-front/src/private/Index.js
+++ b/opencti-platform/opencti-front/src/private/Index.js
@@ -25,6 +25,7 @@ import Message from '../components/Message';
 import { NoMatch, BoundaryRoute } from './components/Error';
 import StixCoreObjectOrStixCoreRelationship from './components/StixCoreObjectOrStixCoreRelationship';
 import { getAccount } from '../services/account.service';
+import FeatureFlag from '../components/feature/FeatureFlag';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -101,7 +102,9 @@ const Index = (me) => {
           <Route path="/dashboard/observations" component={RootObservations} />
           <BoundaryRoute path="/dashboard/threats" component={RootThreats} />
           <BoundaryRoute path="/dashboard/assets" component={RootAssets} />
-          <BoundaryRoute path="/dashboard/risk-assessment" component={RootRiskAssessment} />
+          <FeatureFlag tag={"RISK_ASSESSMENT"}>
+            <BoundaryRoute path="/dashboard/risk-assessment" component={RootRiskAssessment} />
+          </FeatureFlag>
           <BoundaryRoute path="/dashboard/arsenal" component={RootArsenal} />
           <BoundaryRoute path="/dashboard/entities" component={RootEntities} />
           <BoundaryRoute path="/dashboard/data" render={RootData} />

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
@@ -43,6 +43,7 @@ import {
   getAccount
 } from '../../../services/account.service';
 import Dialog from "@material-ui/core/Dialog";
+import FeatureFlag from "../../../components/feature/FeatureFlag";
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -221,18 +222,20 @@ const LeftBar = ({
                 </ListItemIcon>
                 <ListItemText primary={t('Vulnerability Assessment')} />
               </MenuItem>
-              <MenuItem
-                component={Link}
-                to="/dashboard/risk-assessment"
-                selected={location.pathname.includes('/dashboard/risk-assessment')}
-                dense={false}
-                classes={{ root: classes.menuItemNested }}
-              >
-                <ListItemIcon style={{ minWidth: 35 }}>
-                  <FiberManualRecordIcon style={{ fontSize: '0.55rem' }} />
-                </ListItemIcon>
-                <ListItemText primary={t('Risk Assessment')} />
-              </MenuItem>
+              <FeatureFlag tag={"RISK_ASSESSMENT"}>
+                <MenuItem
+                  component={Link}
+                  to="/dashboard/risk-assessment"
+                  selected={location.pathname.includes('/dashboard/risk-assessment')}
+                  dense={false}
+                  classes={{ root: classes.menuItemNested }}
+                >
+                  <ListItemIcon style={{ minWidth: 35 }}>
+                    <FiberManualRecordIcon style={{ fontSize: '0.55rem' }} />
+                  </ListItemIcon>
+                  <ListItemText primary={t('Risk Assessment')} />
+                </MenuItem>
+              </FeatureFlag>
             </MenuList>
         </Security>
       </MenuList>


### PR DESCRIPTION
Adding a Feature Flag component that will allow us to disable specific components and pieces of the UI using environment variables. 

This PR includes two new components in the `opencti-front/src/components/feature` folder.

The first component is the `FeatureProvider` that, at this time, wraps the application as a whole, but essentially should wrap the most root element needed to capture the features to be flagged. The provides a context that is accessed by the `FeatureFlag` component to determine if that flag should render it's children.

The `FeatureFlag` requires two props, children and tag. The tag is the upper snake cased name of the feature. There is an optional prop `alt` that is a placeholder element. It is not required but can be useful for wrapping child elements of a view.

To disable a feature, an environment variable with the pattern `REACT_APP_FEAT_<FEATURE>` should be set to `0`. Right now you can only disable a feature since this is a very simple implementation.

**Example**
``` js
<FeatureProvider>
   <App/>
</FeatureProvider>
```
``` js
<FeatureFlag tag={"SUPER_COOL"} alt={<PlaceHolder/>}>
    ...
</FeatureFlag>
```
``` js
<FeatureFlag tag={"FOO_BAR"}>
   ...
</FeatureFlag>
```
``` shell
export REACT_APP_FEAT_SUPER_COOL=0 && npm run start
```
The children in the FeatureFlag of SUPER_COOL will not render but instead be replaced with the PlaceHolder element given to alt. The FOO_BAR feature will render it's children as normal.