### PR TITLE
fix: correcting the new vulnerability scan submit button enable state

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
+++ b/opencti-platform/opencti-front/src/private/components/vsac/modals/VulnerabilityScan.js
@@ -143,10 +143,10 @@ const classes = {
 		textAlign: 'left',
 	},
 	fileUuploadWwrapper: {
-  		display: 'flex',
-  		flexDirection: 'column',
-        justifyContent: 'center',
-  		alignItems: 'center',
+		display: 'flex',
+		flexDirection: 'column',
+		justifyContent: 'center',
+		alignItems: 'center',
 		padding: 4,
 		border: '1px dashed blue',
 		borderRadius: '5px',
@@ -154,27 +154,25 @@ const classes = {
 		transition: 'backgroundColor 0.3s linear',
 	},
 	customFileLabel: {
-    	position: "relative",
-    	width: "75%",
-  	},
+		position: "relative",
+		width: "75%",
+	},
 	customFileInput: {
-    	position: "absolute",
-    	height: "120px",
-    	width: "600px",
-  	}
+		position: "absolute",
+		height: "120px",
+		width: "600px",
+	}
 };
 
 const VulnerabilityScan = (props) => {
+	const { client_ID } = props;
 
-	const STATUS_INTERVAL = 10000;
+	const STATUS_INTERVAL = 5000;
 
 	const [uploadPercentage, setUploadPercentage] = useState(0);
 	const [currentOrg] = useState(localStorage.getItem('currentOrg'))
-	const [disableSubmit, setDisableSubmit] = useState(false)
-	const { client_ID } = props;
-
+	const [disableSubmit, setDisableSubmit] = useState(true)
 	const { register, handleSubmit, setValue, getValues } = useForm();
-
 	const { ref, ...inputProps } = register("file");
 
 	const fileRef= useRef();
@@ -190,7 +188,7 @@ const VulnerabilityScan = (props) => {
 	const onFinishUpload = (result) => {
 		const {fileId} = result;
 		const data = getValues();
-		data.file = data.scanName;
+		data.file = data.customName ? data.customName : data.scanName;
 		data.fileId = fileId;
 		newScan(data).then(() => {
 			setUploadPercentage(0);
@@ -231,6 +229,7 @@ const VulnerabilityScan = (props) => {
 					console.error(error);
 				});
 		} catch (error) {
+			setDisableSubmit(false)
 			throw error;
 		}
 	};
@@ -238,11 +237,13 @@ const VulnerabilityScan = (props) => {
 	const setUploadedFileName = (event) => {
 		const rawPath = event.target.value
 		if(!rawPath){
+			setDisableSubmit(true)
 			setValue("scanName", null)
 		}else{
 			let fileName = rawPath.substring(rawPath.lastIndexOf("\\") + 1)
 			if(fileName.length === 0) fileName = null
 			setValue("scanName", fileName)
+			setDisableSubmit(false)
 		}
 	};
 
@@ -262,10 +263,19 @@ const VulnerabilityScan = (props) => {
 		setValue('notify', e.target.checked);
 	};
 
+	const handleScanNameInputChange = (e) => {
+		const value = e.target.value
+		if (value === null || value === '') {
+			setValue("customName", null)
+		} else {
+			setValue("customName", value)
+		}
+	}
+
 	const newScan = async (data) => {
 		const params = {
 			file: data.fileId || data.file,
-			scan_name: getValues('scanName'),
+			scan_name: getValues('customName') || getValues("scanName"),
 			vulnerabilityRange: getValues('vulnerability_ranges') || vulnerabilityRanges[0].id,
 			weaknessRange: getValues('weakness_count') || weaknessesCount[0].id,
 			vignette: getValues('weakness_score') || vignettes[0].id,
@@ -275,11 +285,12 @@ const VulnerabilityScan = (props) => {
 		try {
 			await createScan(params, client_ID);
 			setTimeout(() => {
-	        	props.rerenderParentCallback();
-	       		handleClose();
-	      	}, STATUS_INTERVAL);
+				props.rerenderParentCallback();
+				handleClose();
+			}, STATUS_INTERVAL);
 		} catch (error) {
 			console.error(error);
+			setDisableSubmit(false)
 		}
 	};
 
@@ -290,9 +301,7 @@ const VulnerabilityScan = (props) => {
 			style={{ width: 480 }}
 		>
 			<Card>
-				<form
-					onSubmit={handleSubmit((data) => onFormSubmit(data))}
-				>
+				<form onSubmit={handleSubmit((data) => onFormSubmit(data))}>
 					<CardHeader title="New vulnerability scan export file" />
 					<CardContent>
 						<FormControl>
@@ -301,30 +310,26 @@ const VulnerabilityScan = (props) => {
 								width="100%"
 								display="flex" 
 								flexDirection="column"
-						        justifyContent="center"
-						  		alignItems="center"
+								justifyContent="center"
+								alignItems="center"
 								padding="10px"
 								marginBottom="10px"
 								border="1px dashed #fff" 
 								borderRadius="5px"
 								position="relative"
 								transition="backgroundColor 0.3s linear"
-								>
+							>
 								<CloudUploadIcon />
 								<ReactS3Uploader
 									name="file"
-									ref={(ref) => {
-										fileRef.current = ref;
-									}}
+									ref={(ref) => fileRef.current = ref}
 									inputRef={ref}
 									{...inputProps}
 									className="custom-file-input"
 									getSignedUrl={preSignS3}
 									s3path="/uploads/"
 									accept=".nessus, .xml"
-									onProgress={(progress) =>
-										setUploadPercentage(progress)
-									}
+									onProgress={(progress) => setUploadPercentage(progress)}
 									onError={(e) => onErrorUpload(e)}
 									onFinish={onFinishUpload}
 									scrubFilename={updateFileName}
@@ -347,17 +352,17 @@ const VulnerabilityScan = (props) => {
 									width="100%"
 									marginBottom="20px"
 								>
-							      <LinearProgress variant="determinate" value={uploadPercentage} />
-							    </Box>) : null
-							}
+									<LinearProgress variant="determinate" value={uploadPercentage} />
+								</Box>
+							) : null}
 							</FormGroup>
 							<FormGroup row={true}>
 								<TextField
-									style={{ width: '100%' }}
-									label="Scan Name"
+									fullWidth
+									variant={"outlined"}
+									label="Custom Scan Name (Optional)"
 									name="scan_name"
-									defaultValue="A custom scan file name"
-									onChange={(event) => setValue("scanName", event.target.value)}
+									onChange={handleScanNameInputChange}
 								/>
 							</FormGroup>
 							<FormGroup row={true}>
@@ -369,9 +374,7 @@ const VulnerabilityScan = (props) => {
 												id="demo-simple-select"
 												defaultValue={ vulnerabilityRanges[0].id }
 												onChange={(event) => {
-													handleVulnerabilityRanges(
-														event
-													);
+													handleVulnerabilityRanges(event);
 												}}
 											>
 												{vulnerabilityRanges.map(
@@ -398,12 +401,8 @@ const VulnerabilityScan = (props) => {
 											<Select
 												labelId="demo-simple-select-label"
 												id="demo-simple-select"
-												defaultValue={
-													weaknessesCount[0].id
-												}
-												onChange={(event) => {
-													handleWeaknessCount(event);
-												}}
+												defaultValue={weaknessesCount[0].id}
+												onChange={(event) => handleWeaknessCount(event)}
 											>
 												{weaknessesCount.map((item) => (
 													<MenuItem value={item.id}>
@@ -427,9 +426,7 @@ const VulnerabilityScan = (props) => {
 												labelId="demo-simple-select-label"
 												id="demo-simple-select"
 												defaultValue={vignettes[0].id}
-												onChange={(event, value) => {
-													handleWeaknessScore(event);
-												}}
+												onChange={(event) => handleWeaknessScore(event)}
 											>
 												{vignettes.map((item) => (
 													<MenuItem value={item.id}>
@@ -441,12 +438,8 @@ const VulnerabilityScan = (props) => {
 										</ListItemIcon>
 										<ListItemText
 											style={{ width: '100%' }}
-											primary={
-												'Influence Weakness Scores with Vignette'
-											}
-											secondary={
-												'Adjusts some values in the calculations to help prioritize weaknesses.'
-											}
+											primary={'Influence Weakness Scores with Vignette'}
+											secondary={'Adjusts some values in the calculations to help prioritize weaknesses.'}
 										/>
 									</ListItem>
 								</List>
@@ -457,9 +450,7 @@ const VulnerabilityScan = (props) => {
 										<Checkbox
 											name="checkedB"
 											color="primary"
-											onChange={(event) => {
-												handleNotify(event);
-											}}
+											onChange={(event) => handleNotify(event)}
 										/>
 									}
 									label="Notify me via email when the results are ready"


### PR DESCRIPTION
Fixed the submit button for the create new scan dialog to be disabled unless a file is selected to upload. Also needed to fix how the custom name gets stored before submitting by moving it to its own state variable.

Several formatting and cleanup bits.