### PR TITLE
handle situation where selectMap.getNode returns only the metatype __…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
@@ -90,6 +90,9 @@ export const selectObjectIriByIdQuery = (id, type) => {
 }
 // Replacement for selectObjetByIriQuery
 export const selectObjectByIriQuery = (iri, type, select) => {
+  // due to a limitation in the selectMap.getHost capability, its possible to only get back 
+  // a reference to the __typename meta type if all the other members are fragments.
+  if (select.length === 1 && select.includes('__typename')) select = null;
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (!objectMap.hasOwnProperty(type)) {
     let found = false;


### PR DESCRIPTION
Due to a limitation in our selectMap.getNode that occurs when the object only contains a metatype (e.g., __typename) and only inline fragments, the select list will only contain the metatype, which causes an error in further processing.
Fix was to detect this situation and set the select list to null, which will cause the processing to use all the predicates if if they were not requested.


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...