### PR TITLE
AB#5061 - added workaround to handle issue where edit operation is not…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/resolvers.js
@@ -493,6 +493,25 @@ const assetCommonResolvers = {
       return id;
     },
     editAssetLocation: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectLocationQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Asset Location",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
       const query = updateQuery(
           `http://darklight.ai/ns/common#CivicLocation-${id}`,
           "http://darklight.ai/ns/common#CivicLocation",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/resolvers.js
@@ -411,15 +411,26 @@ const computingDeviceResolvers = {
       return id;
     },
     editComputingDeviceAsset: async (_, { id, input }, {dbName, dataSources, selectMap}) => {
-      // check that the ComputingDevice exists
-      const sparqlQuery = selectComputingDeviceQuery(id, null );
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectComputingDeviceQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
         sparqlQuery,
-        queryId: "Select Computing Device",
+        queryId: "Select Computing Device asset",
         singularizeSchema
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://scap.nist.gov/ns/asset-identification#ComputingDevice-${id}`,
         "http://scap.nist.gov/ns/asset-identification#ComputingDevice",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
@@ -152,9 +152,9 @@ export const selectHardwareQuery = (id, select) => {
 export const selectHardwareByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select != null) {
+    if (select.includes('ipv4_address') || select.includes('ipv6_address')) select.push('ip_address');
     select = select.filter(i => i !== 'ipv4_address')
     select = select.filter(i => i !== 'ipv6_address')
-    select.push('ip_address')
   }
   if (select === undefined || select === null) select = Object.keys(hardwarePredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(hardwarePredicateMap, select);

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/software/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/software/resolvers.js
@@ -194,8 +194,12 @@ const softwareResolvers = {
       return id;
     },
     editSoftwareAsset: async ( _, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the ComputingDevice exists
-      const sparqlQuery = selectSoftwareQuery(id, null );
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectSoftwareQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
         sparqlQuery,
@@ -203,6 +207,12 @@ const softwareResolvers = {
         singularizeSchema
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://scap.nist.gov/ns/asset-identification#Software-${id}`,
         "http://scap.nist.gov/ns/asset-identification#Software",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/externalReference.js
@@ -172,6 +172,26 @@ const cyioExternalReferenceResolvers = {
       return id;
     },
     editCyioExternalReference: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectExternalReferenceQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select ExternalReference",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://darklight.ai/ns/common#ExternalReference-${id}`,
         "http://darklight.ai/ns/common#ExternalReference",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/label.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/label.js
@@ -172,6 +172,26 @@ const cyioLabelResolvers = {
       return id;
     },
     editCyioLabel: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectLabelQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Label",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://darklight.ai/ns/common#Label-${id}`,
         "http://darklight.ai/ns/common#Label",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/note.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/note.js
@@ -172,6 +172,26 @@ const cyioNoteResolvers = {
       return id;
     },
     editCyioNote: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectNoteQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Note",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://darklight.ai/ns/common#Note-${id}`,
         "http://darklight.ai/ns/common#Note",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/activity.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/activity.js
@@ -389,21 +389,26 @@ const activityResolvers = {
       return id;
     },
     editActivity: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the Activity exists
-      const sparqlQuery = selectActivityQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Activity",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
+      const sparqlQuery = selectActivityQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Activity",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Activity-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Activity",
@@ -561,21 +566,26 @@ const activityResolvers = {
       return id;
     },
     editAssociatedActivity: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the Activity exists
-      const sparqlQuery = selectAssociatedActivityQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Associated Activity",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
+      const sparqlQuery = selectAssociatedActivityQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Associated Activity",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#AssociatedActivity-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#AssociatedActivity",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
@@ -296,21 +296,26 @@ const actorResolvers = {
       return id;
     },
     editActor: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk response exists
-      const sparqlQuery = selectActorQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Actor",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
+      const sparqlQuery = selectActorQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Actor",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Actor-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Actor",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/characterization.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/characterization.js
@@ -468,22 +468,26 @@ const characterizationResolvers = {
       return id;
     },
     editCharacterization: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the characterization exists
-      const sparqlQuery = selectCharacterizationQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Characterization",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectCharacterizationQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Characterization",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Characterization-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Characterization",
@@ -598,6 +602,26 @@ const characterizationResolvers = {
       return id;
     },
     editFacet: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectFacetQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Facet",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Facet-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Facet",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/evidence.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/evidence.js
@@ -248,6 +248,26 @@ const evidenceResolvers = {
       return id;
     },
     editEvidence: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectEvidenceQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Evidence",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Evidence-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Evidence",
@@ -257,7 +277,7 @@ const evidenceResolvers = {
       await dataSources.Stardog.edit({
         dbName,
         sparqlQuery: query,
-        queryId: "Update Characterization"
+        queryId: "Update Evidence"
       });
       const select = selectEvidenceQuery(id, selectMap.getNode("editEvidence"));
       const result = await dataSources.Stardog.queryById({

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
@@ -385,6 +385,26 @@ const logEntryResolvers = {
       return id;
     },
     editRiskLogEntry: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectRiskLogEntryQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Risk Log Entry",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#RiskLogEntry-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#RiskLogEntry",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/mitigatingFactor.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/mitigatingFactor.js
@@ -303,22 +303,26 @@ const mitigatingFactorResolvers = {
       return id;
     },
     editMitigatingFactor: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the MitigatingFactor exists
-      const sparqlQuery = selectMitigatingFactorQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select MitigatingFactor",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectMitigatingFactorQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Mitigating Factor",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#MitigatingFactor-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#MitigatingFactor",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
@@ -299,21 +299,26 @@ const riskResolvers = {
       return id;
     },
     editRisk: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk exists
-      const sparqlQuery = selectRiskQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Risk",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
+      const sparqlQuery = selectRiskQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Risk",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Risk-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Risk",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/subject.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/subject.js
@@ -396,22 +396,26 @@ const subjectResolvers = {
       return id;
     },
     editSubject: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk response exists
-      const sparqlQuery = selectSubjectQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Subject",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectSubjectQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Subject",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Subject-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#Subject",
@@ -593,22 +597,26 @@ const subjectResolvers = {
       return id;
     },
     editAssessmentSubject: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk response exists
-      const sparqlQuery = selectAssessmentSubjectQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Assessment Subject",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectAssessmentSubjectQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Assessment Subject",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#AssessmentSubject-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#AssessmentSubject",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalLocation.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalLocation.js
@@ -293,22 +293,26 @@ const oscalLocationResolvers = {
       return id;
     },
     editOscalLocation: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
-      // check that the Location exists
-      const sparqlQuery = selectLocationQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select OSCAL Location",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectLocationQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select OSCAL Location",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#Location-${id}`,
         `http://csrc.nist.gov/ns/oscal/common#Location`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalParty.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalParty.js
@@ -387,22 +387,26 @@ const oscalPartyResolvers = {
       return id;
     },
     editOscalParty: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
-      // check that the Party exists
-      const sparqlQuery = selectPartyQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select OSCAL Party",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id','party_type'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectPartyQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select OSCAL Party",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       let reducer = getReducer("PARTY");
       const party = (reducer(response[0]));
 

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleParty.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleParty.js
@@ -252,22 +252,25 @@ const responsiblePartyResolvers = {
       return id;
     },
     editOscalResponsibleParty: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
-      // check that the Party exists
-      const sparqlQuery = selectResponsiblePartyQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select OSCAL Responsible Party",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectResponsiblePartyQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Responsible Party",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#ResponsibleParty-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalRole.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalRole.js
@@ -214,6 +214,26 @@ const oscalRoleResolvers = {
       return id;
     },
     editOscalRole: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectRoleQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select OSCAL Role",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#Role-${id}`,
         "http://csrc.nist.gov/ns/oscal/common#Role",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
@@ -298,22 +298,26 @@ const poamResolvers = {
       return id;
     },
     editPOAM: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk exists
-      const sparqlQuery = selectPOAMQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select Risk",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
-
+      const sparqlQuery = selectPOAMQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select POAM",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#POAM-${id}`,
         "http://csrc.nist.gov/ns/oscal/common#POAM",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poamItem.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poamItem.js
@@ -201,21 +201,26 @@ const poamItemResolvers = {
       return id;
     },
     editPOAMItem: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
-      // check that the risk exists
-      const sparqlQuery = selectPOAMItemQuery(id, null);
-      let response;
-      try {
-        response = await dataSources.Stardog.queryById({
-          dbName,
-          sparqlQuery,
-          queryId: "Select POAM Item",
-          singularizeSchema
-        });
-      } catch (e) {
-        console.log(e)
-        throw e
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
       }
+      const sparqlQuery = selectPOAMItemQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select POAM Item",
+        singularizeSchema
+      })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/poam#Item-${id}`,
         "http://csrc.nist.gov/ns/oscal/poam#Item",


### PR DESCRIPTION
[AB#5061](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5061) - added workaround to handle issue where edit operation is not specified by the UI; added detection of existence before attempting to edit where missing

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...