### PR TITLE
AB#4920 - Updated risk to provide ordering and filtering 

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
@@ -58,6 +58,27 @@ import {
   poamLocalDefinitionPredicateMap, 
 } from '../risk-assessments/poam/resolvers/sparql-query.js';
 
+
+// find IRI of parent
+export const findParentIriQuery = (iri, field, predicateMap) => {
+  if (!predicateMap.hasOwnProperty(field)) return null;
+  if (!iri.startsWith('<')) iri = `<${iri}>`;
+  const predicate = predicateMap[field].predicate;
+  // return the current IRI if predicate isn't a inverse property path
+  if (!predicate.startsWith('^')) return iri;
+  // remove the datatype Property portion of the inverse property path
+  let index = predicate.lastIndexOf('/<');
+  let idPredicate = predicate.substring(0, index);
+  return `
+  SELECT DISTINCT ?parentIri ?objectType
+  FROM <tag:stardog:api:context:local>
+  WHERE {
+    ${iri} ${idPredicate} ?parentIri .
+    ?parentIri <http://darklight.ai/ns/common#object_type> ?objectType .
+  }
+  `
+}
+
 // Replacement for getSubjectIriByIdQuery
 export const selectObjectIriByIdQuery = (id, type) => {
   if (!objectMap.hasOwnProperty(type)) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
@@ -164,6 +164,18 @@ const oscalTaskResolvers = {
   },
   Mutation: {
     createOscalTask: async ( _, {input}, {dbName, selectMap, dataSources} ) => {
+      // TODO: WORKAROUND to remove input fields with null or empty values so creation will work
+      for (const [key, value] of Object.entries(input)) {
+        if (Array.isArray(input[key]) && input[key].length === 0) {
+          delete input[key];
+          continue;
+        }
+        if (value === null || value.length === 0) {
+          delete input[key];
+        }
+      }
+      // END WORKAROUND
+
       // Setup to handle embedded objects to be created
       let dependentTasks = [], relatedTasks = []; 
       let activities, responsibleRoles, assessmentSubjects;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
@@ -1,13 +1,17 @@
 import { riskSingularizeSchema as singularizeSchema } from '../../risk-mappings.js';
 import {compareValues, updateQuery, filterValues} from '../../../utils.js';
 import {UserInputError} from "apollo-server-express";
-import { calculateRiskLevel } from '../../riskUtils.js';
+import { calculateRiskLevel, getLatestRemediationInfo } from '../../riskUtils.js';
 import {
   selectLabelByIriQuery,
   selectExternalReferenceByIriQuery,
   selectNoteByIriQuery,
   getReducer as getGlobalReducer,
 } from '../../../global/resolvers/sparql-query.js';
+import {
+  attachToPOAMQuery,
+  detachFromPOAMQuery,
+} from '../../poam/resolvers/sparql-query.js';
 import {
   getReducer, 
   insertRiskQuery,
@@ -20,6 +24,7 @@ import {
   selectObservationByIriQuery,
   selectRiskResponseByIriQuery,
   selectRiskLogEntryByIriQuery,
+  deleteOriginByIriQuery,
   selectOriginByIriQuery,
 } from './sparql-query.js';
 
@@ -49,9 +54,55 @@ const riskResolvers = {
         limitSize = limit = (args.first === undefined ? response.length : args.first) ;
         offsetSize = offset = (args.offset === undefined ? 0 : args.offset) ;
         filterCount = 0;
-        let riskList ;
+
+        // update the risk level and score before sorting
+        for (let risk of response) {
+          risk.risk_level = 'unknown';
+          if (risk.cvss2_base_score !== undefined || risk.cvss3_base_score !== undefined) {
+            // calculate the risk level
+            const {riskLevel, riskScore} = calculateRiskLevel(risk);
+            risk.risk_score = riskScore;
+            risk.risk_level = riskLevel;
+
+            // clean up
+            delete risk.cvss2_base_score;
+            delete risk.cvss2_temporal_score;
+            delete risk.cvss3_base_score
+            delete risk.cvss3_temporal_score;
+            delete risk.available_exploit;
+            delete risk.exploitability_ease;
+          }
+
+          // retrieve most recent remediation state
+          if (risk.remediation_type !== undefined) {
+            const {responseType, lifeCycle} = getLatestRemediationInfo(risk);
+            if (responseType !== undefined) risk.response_type = responseType;
+            if (lifeCycle !== undefined) risk.lifecycle = lifeCycle;
+            // clean up
+            delete risk.remediation_response_date;
+            delete risk.remediation_type;
+            delete risk.remediation_lifecycle;
+          }
+
+          // calculate the occurrence count
+          if (risk.related_observations !== undefined ) {
+            risk.occurrences = risk.related_observations.length;
+          } else { risk.occurrences = 0; }
+  
+          // fix up deviation values
+          if (risk.risk_status == 'deviation_requested' || risk.risk_status == 'deviation_approved') {
+            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} invalid field value 'risk_status'; fixing`);
+            risk.risk_status = risk.risk_status.replace('_', '-');
+          }
+        }
+
+        // sort the values
+        let riskList, sortBy ;
         if (args.orderedBy !== undefined ) {
-          riskList = response.sort(compareValues(args.orderedBy, args.orderMode ));
+          if (args.orderedBy === 'risk_level') {
+            sortBy = 'risk_score';
+          } else { sortBy = args.orderedBy; }
+          riskList = response.sort(compareValues(sortBy, args.orderMode ));
         } else {
           riskList = response;
         }
@@ -66,32 +117,10 @@ const riskResolvers = {
             continue
           }
 
-          if (risk.id === undefined || risk.id == null ) {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} missing field 'id'; skipping`);
-            continue;
-          }
-
-          if (risk.risk_status == 'deviation_requested' || risk.risk_status == 'deviation_approved') {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} invalid field value 'risk_status'; fixing`);
-            risk.risk_status = risk.risk_status.replace('_', '-');
-          }
-
-          // calculate the risk level
-          risk.risk_level = 'unknown';
-          if (risk.cvss20_base_score !== undefined || risk.cvss30_base_score !== undefined) {
-            // calculate the risk level
-            const {riskLevel, riskScore} = calculateRiskLevel(risk);
-            risk.risk_score = riskScore;
-            risk.risk_level = riskLevel;
-
-            // clean up
-            delete risk.cvss20_base_score;
-            delete risk.cvss20_temporal_score;
-            delete risk.cvss30_base_score
-            delete risk.cvss30_temporal_score;
-            delete risk.exploit_available;
-            delete risk.exploitability;
-          }
+          // if (risk.id === undefined || risk.id == null ) {
+          //   console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} missing field 'id'; skipping`);
+          //   continue;
+          // }
 
           // filter out non-matching entries if a filter is to be applied
           if ('filters' in args && args.filters != null && args.filters.length > 0) {
@@ -168,31 +197,42 @@ const riskResolvers = {
         const reducer = getReducer("RISK");
         let risk = response[0];
 
+        // calculate the risk level
+        risk.risk_level = 'unknown';
+        if (risk.cvss2_base_score !== undefined || risk.cvss3_base_score !== undefined) {
+          // calculate the risk level
+          const {riskLevel, riskScore} = calculateRiskLevel(risk);
+          risk.risk_score = riskScore;
+          risk.risk_level = riskLevel;
+
+          // clean up
+          delete risk.cvss2_base_score;
+          delete risk.cvss2_temporal_score;
+          delete risk.cvss3_base_score
+          delete risk.cvss3_temporal_score;
+          delete risk.available_exploit;
+          delete risk.exploitability_ease;
+        }
+
+        // retrieve most recent remediation state
+        if (risk.remediation_type !== undefined) {
+          const {responseType, lifeCycle} = getLatestRemediationInfo(risk);
+          if (responseType !== undefined) risk.response_type = responseType;
+          if (lifeCycle !== undefined) risk.lifecycle = lifeCycle;
+          // clean up
+          delete risk.remediation_response_date;
+          delete risk.remediation_type;
+          delete risk.remediation_lifecycle;
+        }
+
+        // calculate the occurrence count
+        if (risk.related_observations !== undefined ) {
+          risk.occurrences = risk.related_observations.length;
+        } else { risk.occurrences = 0; }
+
         if (risk.risk_status == 'deviation_requested' || risk.risk_status == 'deviation_approved') {
           console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} invalid field value 'risk_status'; fixing`);
           risk.risk_status = risk.risk_status.replace('_', '-');
-        }
-
-        // calculate the risk level
-        risk.risk_level = 'unknown';
-        if (risk.cvss20_base_score !== undefined || risk.cvss30_base_score !== undefined) {
-          let riskLevel;
-          let score = risk.cvss30_base_score !== undefined ? parseFloat(risk.cvss30_base_score) : parseFloat(risk.cvss20_base_score) ;
-          if (score <= 10 && score >= 9.0) riskLevel = 'very-high';
-          if (score <= 8.9 && score >= 7.0) riskLevel = 'high';
-          if (score <= 6.9 && score >= 4.0) riskLevel = 'moderate';
-          if (score <= 3.9 && score >= 0.1) riskLevel = 'low';
-          if (score == 0) riskLevel = 'very-low';
-          risk.risk_level = riskLevel;
-          risk.risk_score = score;
-
-          // clean up
-          delete risk.cvss20_base_score;
-          delete risk.cvss20_temporal_score;
-          delete risk.cvss30_base_score
-          delete risk.cvss30_temporal_score;
-          delete risk.exploit_available;
-          delete risk.exploitability;
         }
 
         return reducer(risk);  
@@ -210,7 +250,25 @@ const riskResolvers = {
     }
   },
   Mutation: {
-    createRisk: async ( _, {input}, {dbName, selectMap, dataSources} ) => {
+    createRisk: async ( _, {poamId, resultId, input}, {dbName, selectMap, dataSources} ) => {
+      // TODO: WORKAROUND to remove input fields with null or empty values so creation will work
+      for (const [key, value] of Object.entries(input)) {
+        if (Array.isArray(input[key]) && input[key].length === 0) {
+          delete input[key];
+          continue;
+        }
+        if (value === null || value.length === 0) {
+          delete input[key];
+        }
+      }
+      // END WORKAROUND
+
+      // Ensure either the ID of either a POAM or a Assessment Result is supplied
+      if (poamId === undefined && resultId === undefined) {
+        // Default to the POAM
+        poamId = '22f2ad37-4f07-5182-bf4e-59ea197a73dc';
+      }
+
       // Setup to handle embedded objects to be created
       let origins;
       if (input.origins !== undefined) {
@@ -219,14 +277,27 @@ const riskResolvers = {
       }
 
       // create the Risk
-      const {id, query} = insertRiskQuery(input);
+      const {iri, id, query} = insertRiskQuery(input);
       await dataSources.Stardog.create({
         dbName,
         sparqlQuery: query,
         queryId: "Create Risk"
       });
 
-      // add the Risk to its supplied parent
+      // attach the Risk to the supplied POAM
+      if (poamId !== undefined && poamId !== null) {
+        const attachQuery = attachToPOAMQuery(poamId, 'risks', iri );
+        try {
+          await dataSources.Stardog.create({
+            dbName,
+            queryId: "Add Risk to POAM",
+            sparqlQuery: attachQuery
+          });
+        } catch (e) {
+          console.log(e)
+          throw e
+        }
+      }
 
       // create any origins supplied and attach them to the Risk
       if (origins !== undefined && origins !== null ) {
@@ -245,7 +316,13 @@ const riskResolvers = {
       const reducer = getReducer("RISK");
       return reducer(result[0]);
     },
-    deleteRisk: async ( _, {id}, {dbName, dataSources} ) => {
+    deleteRisk: async ( _, {poamId, _resultId, id}, {dbName, dataSources} ) => {
+      // Ensure either the ID of either a POAM or a Assessment Result is supplied
+      if (poamId === undefined && resultId === undefined) {
+        // Default to the POAM
+        poamId = '22f2ad37-4f07-5182-bf4e-59ea197a73dc';
+      }
+
       // check that the risk exists
       const sparqlQuery = selectRiskQuery(id, null);
       let response;
@@ -282,9 +359,22 @@ const riskResolvers = {
         }
       }
 
-      // Detach the Risk from the parent
+      // Detach the Risk from the supplied POAM
+      if (poamId !== undefined && poamId !== null) {
+        const attachQuery = detachFromPOAMQuery(poamId, 'risks', risk.iri );
+        try {
+          await dataSources.Stardog.create({
+            dbName,
+            queryId: "Detaching Risk from POAM",
+            sparqlQuery: attachQuery
+          });
+        } catch (e) {
+          console.log(e)
+          throw e
+        }
+      }
 
-      // Delete the Observation itself
+      // Delete the Risk itself
       const query = deleteRiskQuery(id);
       try {
         await dataSources.Stardog.delete({
@@ -793,6 +883,52 @@ const riskResolvers = {
         return null;
       }
     },
+    occurrences: async (parent, _, {dbName, dataSources, }) => {
+      if (parent.id === undefined) {
+        return 0;
+      }
+
+      // return occurrences value from parent if already exists
+      if (parent.hasOwnProperty('occurrences')) return parent.occurrences;
+
+      const id = parent.id
+      const iri = `<http://csrc.nist.gov/ns/oscal/assessment/common#Risk-${id}>`
+      const sparqlQuery = `
+      SELECT DISTINCT (COUNT(?related_observations) as ?occurrences)
+      FROM <tag:stardog:api:context:local>
+      WHERE {
+        ${iri} <http://csrc.nist.gov/ns/oscal/assessment/common#related_observations> ?related_observations .
+      }
+      `;
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select occurrence count",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response === undefined) {
+        return 0;
+      }
+      if (Array.isArray(response) && response.length > 0) {
+        return( response[0].occurrences)
+      } else {
+        // Handle reporting Stardog Error
+        if (typeof (response) === 'object' && 'body' in response) {
+          throw new UserInputError(response.statusText, {
+            error_details: (response.body.message ? response.body.message : response.body),
+            error_code: (response.body.code ? response.body.code : 'N/A')
+          });
+        } else {
+          return null;
+        }
+      }
+    }
   }
 }
 

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/riskResponse.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/riskResponse.js
@@ -14,6 +14,7 @@ import {
   selectAllRiskResponses,
   deleteRiskResponseQuery,
   selectOscalTaskByIriQuery,
+  selectRequiredAssetByIriQuery,
   selectOriginByIriQuery,
   riskResponsePredicateMap,
 } from './sparql-query.js';

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -108,6 +108,7 @@ const activityReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -132,6 +133,7 @@ const actorReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -148,6 +150,7 @@ const assessmentPlatformReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -167,6 +170,7 @@ const assessmentSubjectReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -186,6 +190,7 @@ const associatedActivityReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -203,6 +208,7 @@ const characterizationReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -221,6 +227,7 @@ const evidenceReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -239,6 +246,7 @@ const facetReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -257,6 +265,7 @@ const logEntryAuthorReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -271,6 +280,7 @@ const mitigatingFactorReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -296,6 +306,7 @@ const observationReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -323,6 +334,7 @@ const originReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -338,6 +350,7 @@ const requiredAssetReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -355,6 +368,7 @@ const riskReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -383,6 +397,10 @@ const riskReducer = (item) => {
     ...(item.priority && {priority: item.priority}),
     ...(item.vendor_dependency && {vendor_dependency: item.vendor_dependency}),
     ...(item.impacted_control_id && {impacted_control_iri: item.impacted_control_id}),
+    ...(item.response_type && {response_type: item.response_type}),
+    ...(item.lifecycle && {lifecycle: item.lifecycle}),
+    ...(item.poam_id && {poam_id: item.poam_id}),
+    ...(item.occurrences && {occurrences: item.occurrences}),
   }
 }
 const riskLogReducer = (item) => {
@@ -392,6 +410,7 @@ const riskLogReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -418,6 +437,7 @@ const riskResponseReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -443,6 +463,7 @@ const subjectReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -461,6 +482,7 @@ const taskReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -492,6 +514,7 @@ const vulnerabilityFacetReducer = (item) => {
   }
 
   return {
+    iri: item.iri,
     id: item.id,
     standard_id: item.id,
     ...(item.object_type && {entity_type: item.object_type}),
@@ -553,7 +576,7 @@ export const selectActivityByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(activityPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(activityPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -712,7 +735,7 @@ export const selectActorByIriQuery = (iri, select) => {
   if (!select.includes('actor_type')) select.push('actor_type');
   const { selectionClause, predicates } = buildSelectVariables(actorPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -851,7 +874,7 @@ export const selectAssessmentPlatformByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(assessmentPlatformPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(assessmentPlatformPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1006,7 +1029,7 @@ export const selectAssessmentSubjectByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(assessmentSubjectPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(assessmentSubjectPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1147,7 +1170,7 @@ export const selectAssociatedActivityByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(associatedActivityPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(associatedActivityPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1302,7 +1325,7 @@ export const selectCharacterizationByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(characterizationPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(characterizationPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1471,7 +1494,7 @@ export const selectEvidenceByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(evidencePredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(evidencePredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1646,7 +1669,7 @@ export const selectFacetByIriQuery = (iri, select) => {
 
   const { selectionClause, predicates } = buildSelectVariables(predicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1801,7 +1824,7 @@ export const selectLogEntryAuthorByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(logEntryAuthorPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(logEntryAuthorPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -1943,7 +1966,7 @@ export const selectMitigatingFactorByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(mitigatingFactorPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(mitigatingFactorPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2077,7 +2100,7 @@ export const selectObservationByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(observationPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(observationPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2224,7 +2247,7 @@ export const selectOriginByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(originPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(originPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2403,7 +2426,7 @@ export const selectRequiredAssetByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(requiredAssetPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(requiredAssetPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2534,19 +2557,25 @@ export const selectRiskByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select === undefined || select === null) select = Object.keys(riskPredicateMap);
 
-  // Update select to impact what predicates get retrieved if looking to calculate risk level
+  // Update select to collect additional predicates if looking to calculate risk level
   if (select.includes('risk_level')) {
-    select.push('cvss20_base_score');
-    select.push('cvss20_temporal_score');
-    select.push('cvss30_base_score');
-    select.push('cvss30_temporal_score');
-    select.push('exploit_available');
-    select.push('exploitability');
+    select.push('cvss2_base_score');
+    select.push('cvss2_temporal_score');
+    select.push('cvss3_base_score');
+    select.push('cvss3_temporal_score');
+    select.push('available_exploit');
+    select.push('exploitability_ease');
+  }
+  // Update select to collect additional predicates if looking for response type
+  if (select.includes('response_type')|| select.includes('response_lifecycle')) {
+    select.push('remediation_response_date')
+    select.push('remediation_type');
+    select.push('remediation_lifecycle')
   }
 
   const { selectionClause, predicates } = buildSelectVariables(riskPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2560,12 +2589,22 @@ export const selectAllRisks = (select, args) => {
   
   // Update select to impact what predicates get retrieved if looking to calculate risk level
   if (select.includes('risk_level')) {
-    select.push('cvss20_base_score');
-    select.push('cvss20_temporal_score');
-    select.push('cvss30_base_score');
-    select.push('cvss30_temporal_score');
-    select.push('exploit_available');
-    select.push('exploitability');
+    select.push('cvss2_base_score');
+    select.push('cvss2_temporal_score');
+    select.push('cvss3_base_score');
+    select.push('cvss3_temporal_score');
+    select.push('available_exploit');
+    select.push('exploitability_ease');
+  }
+  // Update select to collect additional predicates if looking for response type
+  if (select.includes('response_type')|| select.includes('response_lifecycle')) {
+    select.push('remediation_response_date')
+    select.push('remediation_type');
+    select.push('remediation_lifecycle')
+  }
+  // Update select to collect related observation count
+  if (select.includes('occurrences')) {
+    select.push('related_observations')
   }
 
   if (args !== undefined ) {
@@ -2707,7 +2746,7 @@ export const selectRiskLogEntryByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(riskLogPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(riskLogPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -2867,7 +2906,7 @@ export const selectRiskResponseByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(riskResponsePredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(riskResponsePredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -3023,7 +3062,7 @@ export const selectSubjectByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(subjectPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(subjectPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -3156,7 +3195,7 @@ export const selectOscalTaskByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(oscalTaskPredicateMap);
   const { selectionClause, predicates } = buildSelectVariables(oscalTaskPredicateMap, select);
   return `
-  SELECT ${selectionClause}
+  SELECT ?iri ${selectionClause}
   FROM <tag:stardog:api:context:local>
   WHERE {
     BIND(${iri} AS ?iri)
@@ -4145,44 +4184,66 @@ export const riskPredicateMap = {
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
   // Predicate mappings used to gather data for risk level scoring
-  cvss20_base_score: {
+  cvss2_base_score: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#cvss20_base_score>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss20_base_score");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss2_base_score");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  cvss20_temporal_score: {
+  cvss2_temporal_score: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#cvss20_temporal_score>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss20_temporal_score");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss2_temporal_score");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  // cvss20_environmental_score: {
+  // cvss2_environmental_score: {
   //   predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#cvss20_environmental_score>",
-  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss20_environmental_score");},
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss2_environmental_score");},
   //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   // },
-  cvss30_base_score: {
+  cvss3_base_score: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#cvss30_base_score>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss30_base_score");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss3_base_score");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  cvss30_temporal_score: {
+  cvss3_temporal_score: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#cvss30_temporal_score>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss30_temporal_score");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss3_temporal_score");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  // cvss30_environmental_score: {
+  // cvss3_environmental_score: {
   //   predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#cvss30_environmental_score>",
-  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss30_environmental_score");},
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:decimal` : null,  this.predicate, "cvss3_environmental_score");},
   //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   // },
-  exploit_available: {
+  available_exploit: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#exploit_available>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value !== undefined ? `"${value}"^^xsd:boolean` : null, this.predicate, "exploit_available");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value !== undefined ? `"${value}"^^xsd:boolean` : null, this.predicate, "available_exploit");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  exploitability: {
+  exploitability_ease: {
     predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#characterizations>/<http://csrc.nist.gov/ns/oscal/assessment/common#facets>/<http://csrc.nist.gov/ns/oscal/assessment/common#exploitability>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "exploitability");},
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "exploitability_ease");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  // Predicate mappings used to gather data for risk response
+  remediation_response_date: {
+    predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#remediations>/<http://darklight.ai/ns/common#modified>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:dateTime` : null,  this.predicate, "remediation_response_date");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  remediation_type: {
+    predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#remediations>/<http://csrc.nist.gov/ns/oscal/assessment/common#response_type>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "remediation_type");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  remediation_lifecycle: {
+    predicate: "<http://csrc.nist.gov/ns/oscal/assessment/common#remediations>/<http://csrc.nist.gov/ns/oscal/assessment/common#lifecycle>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "remediation_lifecycle");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  // Predicate mappings used to gather data for POAM ID
+  poam_id: {
+    predicate: "^<http://csrc.nist.gov/ns/oscal/assessment/common#related_risks>/<http://fedramp.gov/ns/oscal#poam_id>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "poam_id");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
 }

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -243,8 +243,8 @@
     deleteMitigatingFactor(riskId: ID, id: ID!): String!
     editMitigatingFactor(id: ID!, input: [EditInput]!, commitMessage: String): MitigatingFactor
     # Observation
-    createObservation(input: ObservationAddInput): Observation
-    deleteObservation(id: ID!): String!
+    createObservation(poamId: ID, resultId: ID, input: ObservationAddInput): Observation
+    deleteObservation(poamId: ID, resultId: ID, id: ID!): String!
     editObservation(id: ID!, input: [EditInput]!, commitMessage: String): Observation
     # Origins
     createOrigin(input: OriginAddInput): Origin
@@ -263,8 +263,8 @@
     deleteRiskLogEntry(riskId: ID, id: ID!): String!
     editRiskLogEntry(id: ID!, input: [EditInput]!, commitMessage: String): RiskLogEntry
     # Risk 
-    createRisk(input: RiskAddInput): Risk
-    deleteRisk(id: ID!): String!
+    createRisk(poamId: ID, resultId: ID, input: RiskAddInput): Risk
+    deleteRisk(poamId: ID, resultId: ID, id: ID!): String!
     editRisk(id: ID!, input: [EditInput]!, commitMessage: String): Risk
     # Risk Response
     createRiskResponse(input: RiskResponseAddInput): RiskResponse
@@ -1690,6 +1690,16 @@ type OscalTaskEdge {
     vendor_dependency: RiskAssertionState
     "Identifies a control impacted by this risk."
     impacted_control_id: String
+    # Risk Response
+    "Identifies the type of response to the risk"
+    response_type: ResponseType
+    "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
+    lifecycle: RiskLifeCyclePhase
+    # POAM ID
+    "Identifies the POAM ID associated with the related POAM Item referencing this Risk"
+    poam_id: String
+    "Indicate the number of occurrences of the risk based on observations associated with the risk"
+    occurrences: Int
   }
   input RiskAddInput {
     "Identifies the name for the risk."
@@ -1721,16 +1731,20 @@ type OscalTaskEdge {
     created
     "Modified"
     modified
-    "Label"
-    labels
+    "POAM ID"
+    poam_id
     "Name"
     name
     "Risk Level"
     risk_level
     "Risk Status"
     risk_status
+    "Occurrences"
+    occurrences
     "Deadline"
     deadline
+    "Label"
+    label_name
   }
   # Filtering Types
   input RisksFiltering {
@@ -1746,6 +1760,8 @@ type OscalTaskEdge {
     modified
     "Label"
     label_name
+    "Risk Level"
+    risk_level
     "Risk Status"
     risk_status
     "Deadline"

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
@@ -1,7 +1,7 @@
 import { riskSingularizeSchema as singularizeSchema } from '../../risk-mappings.js';
 import {compareValues, updateQuery, filterValues} from '../../../utils.js';
 import {UserInputError} from "apollo-server-express";
-import { calculateRiskLevel } from '../../riskUtils.js';
+import { calculateRiskLevel, getLatestRemediationInfo } from '../../riskUtils.js';
 import {
   getReducer, 
   insertPOAMQuery,
@@ -73,11 +73,6 @@ const poamResolvers = {
           if (offset) {
             offset--
             continue
-          }
-
-          if (poam.id === undefined || poam.id == null ) {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${poam.iri} missing field 'id'; skipping`);
-            continue;
           }
 
           // filter out non-matching entries if a filter is to be applied
@@ -885,25 +880,43 @@ const poamResolvers = {
           }
 
           if (Array.isArray(response) && response.length > 0) risk = response[0];
-          if (risk.risk_status == 'deviation_requested' || risk.risk_status == 'deviation_approved') {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} invalid field value 'risk_status'; fixing`);
-            risk.risk_status = risk.risk_status.replace('_', '-');
-          }
 
           risk.risk_level = 'unknown';
-          if (risk.cvss20_base_score !== undefined || risk.cvss30_base_score !== undefined) {
+          if (risk.cvss2_base_score !== undefined || risk.cvss3_base_score !== undefined) {
             // calculate the risk level
             const {riskLevel, riskScore} = calculateRiskLevel(risk);
             risk.risk_score = riskScore;
             risk.risk_level = riskLevel;
 
             // clean up
-            delete risk.cvss20_base_score;
-            delete risk.cvss20_temporal_score;
-            delete risk.cvss30_base_score
-            delete risk.cvss30_temporal_score;
-            delete risk.exploit_available;
-            delete risk.exploitability;
+            delete risk.cvss2_base_score;
+            delete risk.cvss2_temporal_score;
+            delete risk.cvss3_base_score
+            delete risk.cvss3_temporal_score;
+            delete risk.available_exploit;
+            delete risk.exploitability_ease;
+          }
+
+          // retrieve most recent remediation state
+          if (risk.remediation_type !== undefined) {
+            const {responseType, lifeCycle} = getLatestRemediationInfo(risk);
+            if (responseType !== undefined) risk.response_type = responseType;
+            if (lifeCycle !== undefined) risk.lifecycle = lifeCycle;
+            // clean up
+            delete risk.remediation_response_date;
+            delete risk.remediation_type;
+            delete risk.remediation_lifecycle;
+          }
+
+          // calculate the occurrence count
+          if (risk.related_observations) {
+            risk.occurrences = risk.related_observations.length;
+          }
+
+          // fix up deviation values
+          if (risk.risk_status == 'deviation_requested' || risk.risk_status == 'deviation_approved') {
+            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} invalid field value 'risk_status'; fixing`);
+            risk.risk_status = risk.risk_status.replace('_', '-');
           }
 
           if ( limit ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/riskUtils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/riskUtils.js
@@ -1,16 +1,44 @@
 
 export const calculateRiskLevel = (risk) => {
   // calculate the risk level
-  let riskLevel, riskScore;
-  riskLevel = 'unknown';
-  if (risk.cvss20_base_score !== undefined || risk.cvss30_base_score !== undefined) {
-    riskScore = risk.cvss30_base_score !== undefined ? parseFloat(risk.cvss30_base_score) : parseFloat(risk.cvss20_base_score) ;
+  let riskLevel = 'unknown', riskScore, cvss2BaseScore, cvss3BaseScore;
+
+  if (Array.isArray(risk.cvss2_base_score)) {
+    let max = Math.max(...risk.cvss2_base_score);
+    let index = risk.cvss2_base_score.indexOf(max);
+    cvss2BaseScore = risk.cvss2_base_score[index];
+  } else { if (risk.cvss2_base_score !== undefined) cvss2BaseScore = risk.cvss2_base_score; }
+  
+  if (Array.isArray(risk.cvss3_base_score)) {
+    let max = Math.max(...risk.cvss3_base_score);
+    let index = risk.cvss3_base_score.indexOf(max);
+    cvss3BaseScore = risk.cvss3_base_score[index];
+  } else {if (risk.cvss3_base_score !== undefined) cvss3BaseScore = risk.cvss3_base_score; }
+
+  if (cvss2BaseScore !== undefined || cvss3BaseScore !== undefined) {
+    riskScore = cvss3BaseScore !== undefined ? parseFloat(cvss3BaseScore) : parseFloat(cvss2BaseScore) ;
     if (riskScore <= 10 && riskScore >= 9.0) riskLevel = 'very-high';
     if (riskScore <= 8.9 && riskScore >= 7.0) riskLevel = 'high';
     if (riskScore <= 6.9 && riskScore >= 4.0) riskLevel = 'moderate';
     if (riskScore <= 3.9 && riskScore >= 0.1) riskLevel = 'low';
     if (riskScore === 0) riskLevel = 'very-low';
   }
-return {riskLevel, riskScore}
+return {riskLevel, riskScore};
+}
+
+export const getLatestRemediationInfo = (risk) => {
+  let responseType, lifeCycle;
+  if (risk.remediation_type !== undefined) {
+    if (risk.remediation_type.length === 1) {
+      responseType = risk.remediation_type !== undefined ? risk.remediation_type[0] : null;
+      lifeCycle = risk.remediation_lifecycle !== undefined ? risk.remediation_lifecycle[0] : null;
+    } else {
+      let max = risk.remediation_response_date.reduce(function (a,b) {return a > b ? a : b; });
+      let index = risk.remediation_response_date.indexOf(max);
+      responseType = risk.remediation_type[index];
+      lifeCycle = risk.remediation_lifecycle[index];
+    }
+  }
+  return {responseType, lifeCycle};
 }
 


### PR DESCRIPTION
Updated Risk to provide ordering and filter support:

- **OrderBy:** POAM ID, Name, Risk Level, Risk Status, Occurrences, Deadline, Label
- **FilterBy:** Created Before, Created After, Risk Level, Risk Status, Deadline, Label

These changes are backward compatible with the current approach, but **DO NOT** provide the sorting/filter capability.  In order take advantage of this capability and get a performance improvement, the UI for the Risks page will need to be modified to use the query contained in the ADO card

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...