### PR TITLE
AB#5077 - add protection against queries for Subjects that don't specify to retrieve subject_type

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -3060,6 +3060,8 @@ export const selectSubjectQuery = (id, select) => {
 export const selectSubjectByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select === undefined || select === null) select = Object.keys(subjectPredicateMap);
+  // defensive code to protect against query not supplying subject type
+  if (!select.hasOwnProperty('subject_type')) select.push('subject_type');
   const { selectionClause, predicates } = buildSelectVariables(subjectPredicateMap, select);
   return `
   SELECT ?iri ${selectionClause}

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -1901,7 +1901,7 @@ type OscalTaskEdge {
     "Indicates the type of subject"
     subject_type: SubjectType!
     "Identifies a reference to a component, inventory-item, location, party, user, or resource."
-    subject_ref: SubjectTarget
+    subject_ref: SubjectTarget!
   }
   input SubjectAddInput {
     "Identifies the name for the referenced subject."

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/sparql-query.js
@@ -248,7 +248,7 @@ export const componentPredicateMap = {
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
   component_type: {
-    predicate: "<http://csrc.nist.gov/ns/oscal/common#componenet_type>",
+    predicate: "<http://csrc.nist.gov/ns/oscal/common#component_type>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null,  this.predicate, "component_type");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },


### PR DESCRIPTION
[AB#5077](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5077) - add protection against queries for Subjects that don't specify to retrieve subject_type

Retrieving a Subject is which is required to have a subject_ref and not retrieving the subject_type as well, which indicates what type of object the subject, is actually flawed.  But there is no way to get GraphQL to enforce this.


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* if retrieving a Subject and the subject_type is missing, automatically add it so internal logic continues to function.
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...