### PR TITLE
AB#5079 - Update OscalTaskAddInput definition to support input of responsible roles and associated activities by ID instead of inline

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -1481,11 +1481,11 @@ input OscalTaskAddInput {
   "Identifies any related tasks"
   related_tasks: [ID]
   "Identifies an individual activity to be performed as part of a task."
-  associated_activities: [AssociatedActivityAddInput]
+  associated_activities: [ID]
   "Identifies a reference to one or more assessment subjects that the task is performed against: component, inventory item, party, users"
   subjects: [AssessmentSubjectAddInput]
   "Identifies the person or organization responsible for performing a specific role related to the task."
-  responsible_roles: [OscalResponsibleRoleAddInput]
+  responsible_roles: [ID]
 }
 # Ordering Types
 enum OscalTaskOrdering {


### PR DESCRIPTION
[AB#5079](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5079) - Update OscalTaskAddInput definition to support input of responsible roles and associated activities by ID instead of inline
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...