### PR TITLE
AB#5049 Fixing lingering popover

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/vsac/Scans.js
+++ b/opencti-platform/opencti-front/src/private/components/vsac/Scans.js
@@ -361,6 +361,7 @@ class Scans extends Component {
     };
 
     const handleScanClick =(event, scan_id) => {
+      handlePopoverClose()
       this.setState({vulnerabilityAnchorEl: event.currentTarget, openScanMenu: scan_id})
     }
 
@@ -742,9 +743,7 @@ class Scans extends Component {
                           <Popover
                             id="mouse-over-popover"
                             className={classes.popover}
-                            classes={{
-                              paper: classes.paper,
-                            }}
+                            classes={{paper: classes.paper}}
                             style={{ pointerEvents: 'none'}}
                             open={openedPopoverId === scan.id}
                             anchorEl={popoverAnchorEl}


### PR DESCRIPTION
fix: making the scan info popover close when the menu for that scan is selected to help with the lingering popover after clicking out of the menu.