### PR TITLE
revert renaming of assessment_subjects back to subjects

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
@@ -633,7 +633,7 @@ const oscalTaskResolvers = {
         return [];
       }
     },
-    assessment_subjects: async (parent, _, {dbName, dataSources, selectMap}) => {
+    subjects: async (parent, _, {dbName, dataSources, selectMap}) => {
       if (parent.subjects_iri === undefined) return [];
       let iriArray = parent.subjects_iri;
       const results = [];

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -1463,7 +1463,7 @@ type OscalTask implements BasicObject & LifecycleObject & OscalObject {
   "Identifies an individual activity to be performed as part of a task."
   associated_activities: [AssociatedActivity]
   "Identifies a reference to one or more assessment subjects that the task is performed against: component, inventory item, party, users"
-  assessment_subjects: [AssessmentSubject]
+  subjects: [AssessmentSubject]
   "Identifies the person or organization responsible for performing a specific role related to the task."
   responsible_roles: [OscalResponsibleParty]
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...