### PR TITLE
AB#5092 - harden missing 'id' detection logic to handle when query didn't request the object's id be returned

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/sparql-query.js
@@ -212,6 +212,7 @@ export function getSelectSparqlQuery( type, select, id, filters, ) {
   var sparqlQuery;
 
   if (select === undefined || select === null) select = Object.keys(assetPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if ( filters !== undefined && id === undefined ) {
     for( const filter of filters) {
@@ -377,6 +378,7 @@ export const selectLocationByIriQuery = (iri, select) => {
 }
 export const selectAllLocations = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(locationPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/sparql-query.js
@@ -244,6 +244,7 @@ export function getSelectSparqlQuery( type, select, id, args, ) {
     select.push('ip_address')
   }
   if (select === undefined || select === null) select = Object.keys(computingDevicePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined && id === undefined ) {
@@ -392,6 +393,7 @@ export const selectComputingDeviceByIriQuery = (iri, select) => {
 }
 export const selectAllComputingDevices = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(computingDevicePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
@@ -182,6 +182,7 @@ export const selectAllHardware = (select, args) => {
     select.push('ip_address')
   }
   if (select === undefined || select === null) select = Object.keys(hardwarePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/sparql-query.js
@@ -95,6 +95,7 @@ export function getSelectSparqlQuery(type, select, id, args, ) {
 
   if (type === 'NETWORK') {
     if (select === undefined || select === null) select = Object.keys(networkPredicateMap);
+    if (!select.includes('id')) select.push('id');
 
     if (args !== undefined ) {
       if ( args.filters !== undefined && id === undefined ) {
@@ -246,6 +247,7 @@ export const selectNetworkByIriQuery = (iri, select) => {
 }
 export const selectAllNetworks = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(networkPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/software/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/software/sparql-query.js
@@ -98,6 +98,7 @@ export function getSelectSparqlQuery(type, select, id, args) {
 
   if (type == 'SOFTWARE') {
     if (select === undefined || select === null) select = Object.keys(softwarePredicateMap);
+    if (!select.includes('id')) select.push('id');
 
     if (args !== undefined ) {
       if ( args.filters !== undefined && id === undefined ) {
@@ -264,6 +265,7 @@ export const selectSoftwareByIriQuery = (iri, select) => {
 }
 export const selectAllSoftware = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(softwarePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/sparql-query.js
@@ -414,6 +414,7 @@ export const selectAddressByIriQuery = (iri, select) => {
 }
 export const selectAllAddresses = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(addressPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -545,6 +546,7 @@ export const selectLabelByIriQuery = (iri, select) => {
 }
 export const selectAllLabels = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(labelPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -716,6 +718,7 @@ export const selectExternalReferenceByIriQuery = (iri, select) => {
 }
 export const selectAllExternalReferences = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(externalReferencePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -846,6 +849,7 @@ export const selectNoteByIriQuery = (iri, select) => {
 }
 export const selectAllNotes = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(notePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -995,6 +999,7 @@ export const selectPhoneNumberByIriQuery = (iri, select) => {
 }
 export const selectAllPhoneNumbers = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(phoneNumberPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
@@ -66,7 +66,7 @@ const actorResolvers = {
             continue;
           }
           if (actor.actor_ref === undefined || actor.actor_ref == null ) {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${actor.iri} missing field 'id'; skipping`);
+            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${actor.iri} missing field 'actor_ref'; skipping`);
           }
 
 

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
@@ -118,10 +118,10 @@ const riskResolvers = {
             continue
           }
 
-          // if (risk.id === undefined || risk.id == null ) {
-          //   console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} missing field 'id'; skipping`);
-          //   continue;
-          // }
+          if (risk.id === undefined || risk.id == null ) {
+            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${risk.iri} missing field 'id'; skipping`);
+            continue;
+          }
 
           // filter out non-matching entries if a filter is to be applied
           if ('filters' in args && args.filters != null && args.filters.length > 0) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -575,6 +575,7 @@ export const selectActivityQuery = (id, select) => {
 export const selectActivityByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select === undefined || select === null) select = Object.keys(activityPredicateMap);
+  
   const { selectionClause, predicates } = buildSelectVariables(activityPredicateMap, select);
   return `
   SELECT ?iri ${selectionClause}
@@ -588,6 +589,7 @@ export const selectActivityByIriQuery = (iri, select) => {
 }
 export const selectAllActivities = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(activityPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -747,6 +749,7 @@ export const selectActorByIriQuery = (iri, select) => {
 }
 export const selectAllActors = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(actorPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -886,6 +889,7 @@ export const selectAssessmentPlatformByIriQuery = (iri, select) => {
 }
 export const selectAllAssessmentPlatforms = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(assessmentPlatformPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -1039,13 +1043,20 @@ export const selectAssessmentSubjectByIriQuery = (iri, select) => {
   }
   `
 }
-export const selectAllAssessmentSubjects = (select, filters) => {
+export const selectAllAssessmentSubjects = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(assessmentSubjectPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
-  // add value of filter's key to cause special predicates to be included
-  if ( filters !== undefined ) {
-    for( const filter of filters) {
-      if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+  if (args !== undefined ) {
+    if ( args.filters !== undefined ) {
+      for( const filter of args.filters) {
+        if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+      }
+    }
+    
+    // add value of orderedBy's key to cause special predicates to be included
+    if ( args.orderedBy !== undefined ) {
+      if (!select.hasOwnProperty(args.orderedBy)) select.push(args.orderedBy);
     }
   }
 
@@ -1182,6 +1193,7 @@ export const selectAssociatedActivityByIriQuery = (iri, select) => {
 }
 export const selectAllAssociatedActivities = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(associatedActivityPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -1337,6 +1349,7 @@ export const selectCharacterizationByIriQuery = (iri, select) => {
 }
 export const selectAllCharacterizations = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(characterizationPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -1506,6 +1519,7 @@ export const selectEvidenceByIriQuery = (iri, select) => {
 }
 export const selectAllEvidence = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(evidencePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -1681,6 +1695,7 @@ export const selectFacetByIriQuery = (iri, select) => {
 }
 export const selectAllFacets = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(facetPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -1834,13 +1849,20 @@ export const selectLogEntryAuthorByIriQuery = (iri, select) => {
   }
   `
 }
-export const selectAllLogEntryAuthors = (select, filters) => {
+export const selectAllLogEntryAuthors = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(logEntryAuthorPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
-  // add value of filter's key to cause special predicates to be included
-  if ( filters !== undefined ) {
-    for( const filter of filters) {
-      if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+  if (args !== undefined ) {
+    if ( args.filters !== undefined ) {
+      for( const filter of args.filters) {
+        if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+      }
+    }
+    
+    // add value of orderedBy's key to cause special predicates to be included
+    if ( args.orderedBy !== undefined ) {
+      if (!select.hasOwnProperty(args.orderedBy)) select.push(args.orderedBy);
     }
   }
 
@@ -1978,6 +2000,7 @@ export const selectMitigatingFactorByIriQuery = (iri, select) => {
 }
 export const selectAllMitigatingFactors = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(mitigatingFactorPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -2112,6 +2135,7 @@ export const selectObservationByIriQuery = (iri, select) => {
 }
 export const selectAllObservations = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(observationPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -2259,6 +2283,7 @@ export const selectOriginByIriQuery = (iri, select) => {
 }
 export const selectAllOrigins = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(originPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -2438,6 +2463,7 @@ export const selectRequiredAssetByIriQuery = (iri, select) => {
 }
 export const selectAllRequiredAssets = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(requiredAssetPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -2587,7 +2613,8 @@ export const selectRiskByIriQuery = (iri, select) => {
 }
 export const selectAllRisks = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(riskPredicateMap);
-  
+  if (!select.includes('id')) select.push('id');
+
   // Update select to impact what predicates get retrieved if looking to calculate risk level
   if (select.includes('risk_level')) {
     select.push('cvss2_base_score');
@@ -2758,6 +2785,7 @@ export const selectRiskLogEntryByIriQuery = (iri, select) => {
 }
 export const selectAllRiskLogEntries = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(riskLogPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -2918,6 +2946,7 @@ export const selectRiskResponseByIriQuery = (iri, select) => {
 }
 export const selectAllRiskResponses = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(riskResponsePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -3076,6 +3105,7 @@ export const selectSubjectByIriQuery = (iri, select) => {
 }
 export const selectAllSubjects = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(subjectPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -3196,6 +3226,7 @@ export const selectOscalTaskQuery = (id, select) => {
 export const selectOscalTaskByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select === undefined || select === null) select = Object.keys(oscalTaskPredicateMap);
+  if (!select.includes('id')) select.push('id');
   if (select.includes('timing')) {
     select.push('on_date');
     select.push('start_date');
@@ -3217,6 +3248,8 @@ export const selectOscalTaskByIriQuery = (iri, select) => {
 }
 export const selectAllOscalTasks = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(oscalTaskPredicateMap);
+  if (!select.includes('id')) select.push('id');
+
   if (select.includes('timing')) {
     select.push('on_date');
     select.push('start_date');

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/sparql-query.js
@@ -141,6 +141,7 @@ export const selectComponentByIriQuery = (iri, select) => {
 }
 export const selectAllComponents = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(componentPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined) {
     // add value of filter's key to cause special predicates to be included

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/sparql-query.js
@@ -130,6 +130,7 @@ export const selectInventoryItemByIriQuery = (iri, select) => {
 }
 export const selectAllInventoryItems = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(inventoryItemPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined) {
     // add value of filter's key to cause special predicates to be included

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/sparql-query.js
@@ -272,13 +272,20 @@ export const selectExternalIdentifierByIriQuery = (iri, select) => {
   }
   `
 }
-export const selectAllExternalIdentifiers = (select, filters) => {
+export const selectAllExternalIdentifiers = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(externalIdentifierPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
-  // add value of filter's key to cause special predicates to be included
-  if ( filters !== undefined ) {
-    for( const filter of filters) {
-      if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+  if (args !== undefined ) {
+    if ( args.filters !== undefined ) {
+      for( const filter of args.filters) {
+        if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+      }
+    }
+    
+    // add value of orderedBy's key to cause special predicates to be included
+    if ( args.orderedBy !== undefined ) {
+      if (!select.hasOwnProperty(args.orderedBy)) select.push(args.orderedBy);
     }
   }
 
@@ -404,6 +411,7 @@ export const selectLocationByIriQuery = (iri, select) => {
 }
 export const selectAllLocations = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(locationPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -542,6 +550,7 @@ export const selectPartyByIriQuery = (iri, select) => {
 }
 export const selectAllParties = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(partyPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -668,6 +677,7 @@ export const selectResponsiblePartyByIriQuery = (iri, select) => {
 }
 export const selectAllResponsibleParties = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(responsiblePartyPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -835,6 +845,7 @@ export const selectRoleByIriQuery = (iri, select) => {
 }
 export const selectAllRoles = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(rolePredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/sparql-query.js
@@ -407,6 +407,7 @@ export const selectPOAMByIriQuery = (iri, select) => {
 }
 export const selectAllPOAMs = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(poamPredicateMap);
+  if (!select.includes('id')) select.push('id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
@@ -560,7 +561,8 @@ export const selectPOAMItemByIriQuery = (iri, select) => {
 }
 export const selectAllPOAMItems = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(poamItemPredicateMap);
-  
+  if (!select.includes('id')) select.push('id');
+
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {
       for( const filter of args.filters) {


### PR DESCRIPTION
[AB#5092](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5092) - harden missing 'id' detection logic to handle when query didn't request the object's id be returned

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...