### PR TITLE
AB#5114 - Fix SPARQL query syntax, properly handle duplicates; added error hand…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/externalReference.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/externalReference.js
@@ -164,11 +164,20 @@ const cyioExternalReferenceResolvers = {
     },
     deleteCyioExternalReference: async ( _, {id}, {dbName, dataSources} ) => {
       const query = deleteExternalReferenceQuery(id);
-      await dataSources.Stardog.delete({
+      let results = await dataSources.Stardog.delete({
         dbName,
         sparqlQuery: query,
         queryId: "Delete External Reference"
       });
+      if (results !== undefined && 'status' in results) {
+        if (results.ok === false || results.status > 299) {
+          // Handle reporting Stardog Error
+          throw new UserInputError(results.statusText, {
+            error_details: (results.body.message ? results.body.message : results.body),
+            error_code: (results.body.code ? results.body.code : 'N/A')
+          });
+        }
+      }
       return id;
     },
     editCyioExternalReference: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
@@ -198,11 +207,20 @@ const cyioExternalReferenceResolvers = {
         input,
         externalReferencePredicateMap
       )
-      await dataSources.Stardog.edit({
+      let results = await dataSources.Stardog.edit({
         dbName,
         sparqlQuery: query,
         queryId: "Update External Reference"
       });
+      if (results !== undefined && 'status' in results) {
+        if (results.ok === false || results.status > 299) {
+          // Handle reporting Stardog Error
+          throw new UserInputError(results.statusText, {
+            error_details: (results.body.message ? results.body.message : results.body),
+            error_code: (results.body.code ? results.body.code : 'N/A')
+          });
+        }
+      }
       const select = selectExternalReferenceQuery(id, selectMap.getNode("editCyioExternalReference"));
       const result = await dataSources.Stardog.queryById({
         dbName,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/label.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/resolvers/label.js
@@ -164,11 +164,20 @@ const cyioLabelResolvers = {
     },
     deleteCyioLabel: async ( _, {id}, {dbName, dataSources} ) => {
       const query = deleteLabelQuery(id);
-      await dataSources.Stardog.delete({
+      let results = await dataSources.Stardog.delete({
         dbName,
         sparqlQuery: query,
         queryId: "Delete Label"
       });
+      if (results !== undefined && 'status' in results) {
+        if (results.ok === false || results.status > 299) {
+          // Handle reporting Stardog Error
+          throw new UserInputError(results.statusText, {
+            error_details: (results.body.message ? results.body.message : results.body),
+            error_code: (results.body.code ? results.body.code : 'N/A')
+          });
+        }
+      }
       return id;
     },
     editCyioLabel: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
@@ -198,11 +207,21 @@ const cyioLabelResolvers = {
         input,
         labelPredicateMap
       )
-      await dataSources.Stardog.edit({
+      let results = await dataSources.Stardog.edit({
         dbName,
         sparqlQuery: query,
         queryId: "Update Label"
       });
+      if (results !== undefined && 'status' in results) {
+        if (results.ok === false || results.status > 299) {
+          // Handle reporting Stardog Error
+          throw new UserInputError(results.statusText, {
+            error_details: (results.body.message ? results.body.message : results.body),
+            error_code: (results.body.code ? results.body.code : 'N/A')
+          });
+        }
+      }
+
       const select = selectLabelQuery(id, selectMap.getNode("editCyioLabel"));
       const result = await dataSources.Stardog.queryById({
         dbName,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/utils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/utils.js
@@ -184,22 +184,25 @@ export const buildSelectVariables = (predicateMap, selects) => {
 }
 
 export const updateQuery = (iri, type, input, predicateMap) => {
-  let deletePredicates = [], insertPredicates = [], replaceBindingPredicates = [];
+  let deletePredicates = [], insertPredicates = [], replaceBindingPredicates = [], replacementPredicate;
   for(const {key, value, operation} of input) {
     if (!predicateMap.hasOwnProperty(key)) continue;
     for(const itr of value) {
-      const predicate = predicateMap[key].binding(`<${iri}>`, itr);
+      const predicate = predicateMap[key].binding(`<${iri}>`, itr) + ' .';
       switch (operation) {
         case UpdateOps.ADD:
+          if (insertPredicates.includes(predicate)) continue;
           insertPredicates.push(predicate);
           break;
         case UpdateOps.REMOVE:
+          if (deletePredicates.includes(predicate)) continue;
           deletePredicates.push(predicate);
           break;
         case UpdateOps.REPLACE:
         default:    // replace is the default behavior when the operation is not supplied.
-          insertPredicates.push(predicate);
-          replaceBindingPredicates.push(predicateMap[key].binding(`<${iri}>`))
+          replacementPredicate = predicateMap[key].binding(`<${iri}>`) + ' .';
+          if (!insertPredicates.includes(predicate)) insertPredicates.push(predicate);
+          if (!replaceBindingPredicates.includes(replacementPredicate)) replaceBindingPredicates.push(replacementPredicate)
           break;
         }
     }


### PR DESCRIPTION
[AB#5114](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5114) - Fix SPARQL query syntax, properly handle duplicates; added error handle in delete and edit mutations of Note, ExternalReference, Label

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...