### PR TITLE
AB#5109 - fix incorrect field name to allow SoftwareAssets to be created

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/assets/software/SoftwareCreationDetails.js
+++ b/opencti-platform/opencti-front/src/private/components/assets/software/SoftwareCreationDetails.js
@@ -182,12 +182,12 @@ class SoftwareCreationDetailsComponent extends Component {
                   <Field
                     component={TextField}
                     variant='outlined'
-                    name="motherboard_id"
+                    name="cpe_identifier"
                     size='small'
                     fullWidth={true}
                   // helperText={
                   //   <SubscriptionFocus
-                  //   fieldName="motherboard_id"
+                  //   fieldName="cpe_identifier"
                   //   />
                   // }
                   />

--- a/opencti-platform/opencti-front/src/private/components/assets/software/SoftwareEditionDetails.js
+++ b/opencti-platform/opencti-front/src/private/components/assets/software/SoftwareEditionDetails.js
@@ -241,7 +241,7 @@ class SoftwareEditionDetailsComponent extends Component {
                     fullWidth={true}
                   // helperText={
                   //   <SubscriptionFocus
-                  //   fieldName="motherboard_id"
+                  //   fieldName="cpe_identifier"
                   //   />
                   // }
                   />


### PR DESCRIPTION
[AB#5109](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5109) - fix incorrect field name to allow SoftwareAssets to be created

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...