### PR TITLE
AB#5181 - add logging anytime a field is specified to be edited that is invalid for the target object type

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/utils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/utils.js
@@ -186,7 +186,10 @@ export const buildSelectVariables = (predicateMap, selects) => {
 export const updateQuery = (iri, type, input, predicateMap) => {
   let deletePredicates = [], insertPredicates = [], replaceBindingPredicates = [], replacementPredicate;
   for(const {key, value, operation} of input) {
-    if (!predicateMap.hasOwnProperty(key)) continue;
+    if (!predicateMap.hasOwnProperty(key)) {
+      console.error(`[CYIO] UNKNOWN-FIELD Unknown field '${key}' for object ${iri}`);        
+      continue;
+    }
     let itr;
     for(itr of value) {
       if (key === 'description' || key === 'statement') {


### PR DESCRIPTION
[AB#5181](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/5181) - add logging anytime a field is specified to be edited that is that is invalid for the target object type

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...