### PR TITLE
AB#5190: Add workaround to fix malformed values of a RiskLogEntry's entry_type

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
@@ -71,15 +71,15 @@ const logEntryResolvers = {
 
         // for each Log Entry in the result set
         for (let logEntry of logEntryList) {
+          if (logEntry.id === undefined || logEntry.id == null ) {
+            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${logEntry.iri} missing field 'id'; skipping`);
+            continue;
+          }
+
           // skip down past the offset
           if (offset) {
             offset--
             continue
-          }
-
-          if (logEntry.id === undefined || logEntry.id == null ) {
-            console.log(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${logEntry.iri} missing field 'id'; skipping`);
-            continue;
           }
 
           // filter out non-matching entries if a filter is to be applied
@@ -89,6 +89,14 @@ const logEntryResolvers = {
             }
             filterCount++;
           }
+
+          //TODO: WORKAROUND data issues
+          if (logEntry.hasOwnProperty('entry_type')) {
+            for (let entry in logEntry.entry_type) {
+              logEntry.entry_type[entry] = logEntry.entry_type[entry].replace(/_/g,'-');
+            }
+          }
+          //END WORKAROUND
 
           // if haven't reached limit to be returned
           if (limit) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
@@ -805,6 +805,14 @@ const riskResolvers = {
           }
           if (response === undefined) return null;
           if (Array.isArray(response) && response.length > 0) {
+            //TODO: WORKAROUND data issues
+            if (response[0].hasOwnProperty('entry_type')) {
+              for (let entry in response[0].entry_type) {
+                response[0].entry_type[entry] = response[0].entry_type[entry].replace(/_/g,'-');
+              }
+            }
+            //END WORKAROUND
+
             if ( limit ) {
               let edge = {
                 cursor: iri,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...