### PR TITLE
AB#4317/AB5280 - Added mutator definitions for requesting export of OSCAL JSON and Risk Report Generation

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscal-common.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscal-common.js
@@ -77,6 +77,17 @@ const oscalCommonResolvers = {
     external: 'external',
     general_public: 'general-public',
   },
+  OscalMediaType: {
+    application_oscal_json: 'application/oscal+json',
+    application_oscal_xml: 'application/oscal+xml',
+    application_oscal_yaml: 'application/oscal+yaml',
+    application_oscal_csv: 'application/oscal+csv',
+  },
+  ReportMediaType: {
+    markdown: 'text/markdown',
+    html: 'text/html',
+    pdf: 'application/pdf',
+  },
   PartyOrComponent: {
     __resolveType: (item) => {
       return objectMap[item.entity_type].graphQLType;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
@@ -118,7 +118,118 @@
     createOscalUser(input: OscalUserAddInput): OscalUser
     deleteOscalUser(id: ID!): String!
     editOscalUser( id: ID!, input: [EditInput]!, commitMessage: String): OscalUser
+    # Export OSCAL Model
+    exportOscal(model: OscalModelType, id: ID, media_type: OscalMediaType): ID
+    # Generate Report
+    generateRiskReport( 
+      report: RiskReportType!, 
+      id: ID, 
+      media_type: ReportMediaType, 
+      options: [RiskReportOption]): ID
   }
+
+  "Defines the types of OSCAL Models"
+  enum OscalModelType {
+    "OSCAL Assessment Plan"
+    ap
+    "OSCAL Assessment Results"
+    ar
+    "OSCAL Catalog"
+    catalog
+    "OSCAL Component Definition"
+    component_definition
+    "OSCAL Plan of Action and Milestones"
+    poam
+    "OSCAL Profile"
+    profile
+    "OSCAL System Security Plan"
+    ssp
+  }
+
+  "Defines the media types for OSCAL export"
+  enum OscalMediaType {
+    "application/oscal+json"
+    application_oscal_json
+    "application/oscal+xml"
+    application_oscal_xml
+    "application/oscal+yaml"
+    application_oscal_yaml
+    "application/oscal+csv"
+    application_oscal_csv
+  }
+
+  "Defines an risk reporting option"
+  input RiskReportOption {
+    "Identifies the name of the option"
+    name: ReportOptionType!
+    "Identifies the value(s) for the option"
+    values: [String!]
+  }
+
+  "Defines the types of Risk Reports"
+  enum RiskReportType {
+    "Security Assessment Report (SAR)"
+    sar
+    "Vulnerability Assessment Report (VAR)"
+    var
+    "Asset Inventory Report (AIR)"
+    air
+    "Cybersecurity Risk Assessment Report (CRA)"
+    cra
+    "Threat Assessment Report (TAR)"
+    tar
+  } 
+
+  "Defines the Options for Reports"
+  enum ReportOptionType {
+    "Appendices"
+    appendices
+    "Description"
+    description
+    "Purpose"
+    purpose
+    "Max Items"
+    max_items
+    "Sections"
+    sections
+    "Title"
+    title
+  }
+
+  "Defines the media types for Reports"
+  enum ReportMediaType {
+    "text/markdown"
+    markdown
+    "application/pdf"
+    pdf
+    "text/html"
+    html
+  }
+
+## Report-specifics
+  "Defines the sections in a Security Assessment Report"
+  enum SarSections {
+    "Risk Tracking Details"
+    tracking
+    "Collected During Testing"
+    collected_during_testing
+    "Mitigating Factors"
+    mitigating_factor  }
+
+  "Appendices of a Security Assessment Report"
+  enum SarAppendices {
+    "Database Scan"
+    db_scan
+    "Web Scan"
+    web_scan
+    "Penetration Testing"
+    pen_test
+    "Manual Test"
+    manual_test
+  }
+
+
+
 
   "Defines identifying information about a system privilege held by the user."
   type AuthorizedPrivilege {


### PR DESCRIPTION
[AB#4317](https://dev.azure.com/DkLt/1f741bf4-fc05-4308-8389-99678c3c5ab2/_workitems/edit/4317)/AB5280 - Added mutator definitions for requesting export of OSCAL in machine-readable format per NIST OSCAL JSON schema and Risk Report Generation to support generation of SAR.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...