### PR TITLE
AB#4887:  Added  GraphQL Query to POAM local-definitions required by both the machine and human-readable SAR

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/Source.js
+++ b/opencti-platform/opencti-front/src/private/components/common/form/Source.js
@@ -46,7 +46,7 @@ const ComponentListQuery = graphql`
   query SourceComponentListQuery{
     componentList(filters: [
     {
-      key: asset_type,
+      key: component_type,
       values: "software"
     }
     ]){
@@ -146,7 +146,7 @@ class Source extends Component {
             filterBy = {
               filters: [
                 {
-                  key: 'asset_type',
+                  key: 'component_type',
                   values: 'software',
                 },
               ],

--- a/opencti-platform/opencti-front/src/private/components/dataEntities/data/responsibleParties/EntitiesResponsiblePartiesCards.js
+++ b/opencti-platform/opencti-front/src/private/components/dataEntities/data/responsibleParties/EntitiesResponsiblePartiesCards.js
@@ -126,7 +126,7 @@ export default createPaginationContainer(
         first: { type: "Int", defaultValue: 50 }
         offset: { type: "Int", defaultValue: 0 }
         cursor: { type: "ID" }
-        orderedBy: { type: "OscalResponsiblePartyOrdering", defaultValue: label_name }
+        orderedBy: { type: "OscalResponsiblePartyOrdering", defaultValue: name }
         orderMode: { type: "OrderingMode", defaultValue: asc }
         filters: { type: "[OscalResponsiblePartyFiltering]" }
         filterMode: { type: "FilterMode" }

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/typeDefs.graphql
@@ -142,42 +142,47 @@
     workstation
   }
 
-  "Defines network protocols"
+  "Defines common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
   enum NetworkAssetProtocol {
-      TCP
-      UDP
-      ICMP
-      TLS
-      SSL
-      DHCP
-      DNS
-      HTTP
-      HTTPS
-      NFS
-      POP3
-      SMTP
-      SNMP
-      FTP
-      NTP
-      IRC
-      Telnet
-      SSH
-      TFTP
-      IMAP
-      ARP
-      NetBIOS
-      SOAP
-      IP
-      IPSEC
-      IPX
-      NAT
-      OSPF
-      RDP
-      RIP
-      RPC
-      SPX
-      SMB
-      SOCKS
+    ""
+    TCP
+    UDP
+    "Internet Control Message Protocol"
+    ICMP
+    "Transport Layer Security"
+    TLS
+    "Secure Socket Layer"
+    SSL
+    DHCP
+    DNS
+    HTTP
+    HTTPS
+    NFS
+    POP3
+    SMTP
+    SNMP
+    FTP
+    NTP
+    IRC
+    Telnet
+    SSH
+    TFTP
+    "Interactive Mail Access Protocol"
+    IMAP
+    ARP
+    NetBIOS
+    SOAP
+    IP
+    IPSEC
+    IPX
+    NAT
+    OSPF
+    RDP
+    RIP
+    RPC
+    SPX
+    SMB
+    SOCKS
   }
 
 #####  AssetLocation 

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
@@ -645,6 +645,11 @@ export const hardwarePredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_software");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
+  installed_software_name: {
+    predicate: "<http://scap.nist.gov/ns/asset-identification#installed_software>/<http://scap.nist.gov/ns/asset-identification#name>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_software_name");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
   ip_address: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#ip_address>", // this should really be ipv4_address in ontology
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip_address");},

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/global-utils.js
@@ -51,7 +51,9 @@ import {
   locationPredicateMap as oscalLocationPredicateMap, attachToLocationQuery, detachFromLocationQuery,
   partyPredicateMap, attachToPartyQuery, detachFromPartyQuery,
   responsiblePartyPredicateMap, attachToResponsiblePartyQuery, detachFromResponsiblePartyQuery,
-  rolePredicateMap, attachToRoleQuery, detachFromRoleQuery,
+  attachToResponsibleRoleQuery, detachFromResponsibleRoleQuery,
+  attachToRoleQuery, detachFromRoleQuery,
+  rolePredicateMap, 
 } from '../risk-assessments/oscal-common/resolvers/sparql-query.js';
 import {
   poamPredicateMap, attachToPOAMQuery, detachFromPOAMQuery,
@@ -359,6 +361,14 @@ export const objectMap = {
     alternateKey: "responsible-party",
     graphQLType: "OscalResponsibleParty",
     iriTemplate: "http://csrc.nist.gov/ns/oscal/common#ResponsibleParty"
+  },
+  "oscal-responsible-role": {
+    predicateMap: responsiblePartyPredicateMap,
+    attachQuery: attachToResponsibleRoleQuery,
+    detachQuery: detachFromResponsibleRoleQuery,
+    alternateKey: "responsible-role",
+    graphQLType: "OscalResponsibleRole",
+    iriTemplate: "http://csrc.nist.gov/ns/oscal/common#ResponsibleRole"
   },
   "oscal-role": {
     predicateMap: rolePredicateMap,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/global/typeDefs/common.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/global/typeDefs/common.graphql
@@ -71,6 +71,14 @@
     target_id: ID!
   }
 
+  "Defines the identifying information about a complex type"
+  interface ComplexDatatype {
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+  }
+  
   "Defines the identifying information about a lifecycle object"
   interface LifecycleObject {
     "Identities the date and time at which the object was originally created."

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/assessmentAsset.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/assessmentAsset.js
@@ -170,6 +170,18 @@ const assessmentAssetResolvers = {
       limitSize = limit = (args.first === undefined ? response.length : args.first) ;
       offsetSize = offset = (args.offset === undefined ? 0 : args.offset) ;
       filterCount = 0;
+
+      // compose name to include version and patch level
+      for (let component of response) {
+        let name = component.name;
+        if (component.hasOwnProperty('vendor_name')) {
+          if (!component.name.startsWith(component.vendor_name)) name = `${component.vendor_name} ${component.name}`;
+        }
+        if (component.hasOwnProperty('version')) name = `${name} ${component.version}`; 
+        if (component.hasOwnProperty('patch_level')) name = `$${name} ${component.patch_level}`;
+        component.name = name;
+      }
+
       let componentList ;
       if (args.orderedBy !== undefined ) {
         componentList = response.sort(compareValues(args.orderedBy, args.orderMode ));

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -116,7 +116,7 @@ export const getSubjectIriByIdQuery = (id, subjectType) => {
 const activityReducer = (item) => {
   // if no object type was returned, compute the type from the IRI
   if ( item.object_type === undefined ) {
-    item.object_type = 'activity';
+    item.object_type = 'oscal-activity';
   }
 
   return {
@@ -608,7 +608,7 @@ export const insertActivityQuery = (propValues) => {
       ${iri} a <http://csrc.nist.gov/ns/oscal/common#Object> .
       ${iri} a <http://darklight.ai/ns/common#Object> .
       ${iri} <http://darklight.ai/ns/common#id> "${id}" .
-      ${iri} <http://darklight.ai/ns/common#object_type> "activity" . 
+      ${iri} <http://darklight.ai/ns/common#object_type> "oscal-activity" . 
       ${iri} <http://darklight.ai/ns/common#created> "${timestamp}"^^xsd:dateTime . 
       ${iri} <http://darklight.ai/ns/common#modified> "${timestamp}"^^xsd:dateTime . 
       ${insertPredicates}
@@ -1106,7 +1106,8 @@ export const selectAssessmentPlatformByIriQuery = (iri, select) => {
   }
   `
 }
-export const selectAllAssessmentPlatforms = (select, args) => {
+export const selectAllAssessmentPlatforms = (select, args, parent) => {
+  let constraintClause = '';
   if (select === undefined || select === null) select = Object.keys(assessmentPlatformPredicateMap);
   if (!select.includes('id')) select.push('id');
 
@@ -1124,12 +1125,32 @@ export const selectAllAssessmentPlatforms = (select, args) => {
   }
 
   const { selectionClause, predicates } = buildSelectVariables(assessmentPlatformPredicateMap, select);
+  // add constraint clause to limit to those that are referenced by the specified POAM
+  if (parent !== undefined && parent.iri !== undefined) {
+    let classTypeIri, predicate;
+    if (parent.entity_type === 'assessment-asset') {
+      classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#AssessmentAsset>';
+      predicate = '<http://csrc.nist.gov/ns/oscal/assessment/common#assessment_platforms>';
+    }
+    // define a constraint to limit retrieval to only those referenced by the parent
+    constraintClause = `
+    {
+      SELECT DISTINCT ?iri
+      WHERE {
+          <${parent.iri}> a ${classTypeIri} ;
+            ${predicate} ?iri .
+      }
+    }
+    `;
+  }
+
   return `
   SELECT DISTINCT ?iri ${selectionClause} 
   FROM <tag:stardog:api:context:local>
   WHERE {
     ?iri a <http://csrc.nist.gov/ns/oscal/assessment/common#AssessmentPlatform> . 
     ${predicates}
+    ${constraintClause}
   }
   `
 }

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -3004,6 +3004,9 @@ export const selectRiskByIriQuery = (iri, select) => {
   if (select === undefined || select === null) select = Object.keys(riskPredicateMap);
   if (!select.includes('id')) select.push('id');
 
+  // fetch the uuid of each related_observation and related_risk as these are commonly used
+  if (select.includes('related_observations')) select.push('related_observation_ids');
+
   // Update select to collect additional predicates if looking to calculate risk level
   if (select.includes('risk_level')) {
     if (!select.includes('cvss2_base_score')) select.push('cvss2_base_score');

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -2129,7 +2129,7 @@ type OscalTaskEdge {
 #
   # union StatementOrObjects = ControlStatement | ControlObjective
   union ActorTarget = OscalParty | AssessmentPlatform | Component
-  union PartyOrComponent = OscalParty | HardwareComponent | NetworkComponent | ServiceComponent | SoftwareComponent | SystemComponent
+  union PartyOrComponent = OscalParty | Component | HardwareComponent | NetworkComponent | ServiceComponent | SoftwareComponent | SystemComponent
   union SubjectTarget = Component | InventoryItem | OscalLocation | OscalParty | OscalUser | OscalResource | SoftwareAsset | HardwareAsset
 
 ## Enumerations

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/typeDefs.graphql
@@ -1,453 +1,502 @@
-  # declares the query entry-points for this type
-  extend type Query {
-    # Activity
-    activity(id: ID!): Activity
-    activities( 
-      first: Int
-      offset: Int
-      orderedBy: ActivityOrdering
-      orderMode: OrderingMode
-      filters: [ActivityFiltering]
-      filterMode: FilterMode
-      search: String
-    ): ActivityConnection
-    # Actor
-    actor(id: ID!): Actor
-    actors( 
-      first: Int
-      offset: Int
-      orderedBy: ActorOrdering
-      orderMode: OrderingMode
-      filters: [ActorFiltering]
-      filterMode: FilterMode
-      search: String
-    ): ActorConnection
-    # Assessment Log Entry
-    assessmentLogEntry(id: ID!): AssessmentLogEntry
-    assessmentLogEntries( 
-      first: Int
-      offset: Int
-      orderedBy: AssessmentLogEntriesOrdering
-      orderMode: OrderingMode
-      filters: [AssessmentLogEntriesFiltering]
-      filterMode: FilterMode
-      search: String
-    ): AssessmentLogEntryConnection
-    # AssessmentAsset
-    assessmentAsset(id: ID!): AssessmentAsset
-    assessmentAssets(
-      first: Int
-      offset: Int
-    ): AssessmentAssetConnection
-    # AssessmentPlatform
-    assessmentPlatform(id: ID!): AssessmentPlatform
-    assessmentPlatforms( 
-      first: Int
-      offset: Int
-      orderedBy: AssessmentPlatformOrdering
-      orderMode: OrderingMode
-      filters: [AssessmentPlatformFiltering]
-      filterMode: FilterMode
-      search: String
-    ): AssessmentPlatformConnection
-    # AssessmentSubject
-    assessmentSubject(id: ID!): AssessmentSubject
-    assessmentSubjects( 
-      first: Int
-      offset: Int
-      orderedBy: AssessmentSubjectOrdering
-      orderMode: OrderingMode
-      filters: [AssessmentSubjectFiltering]
-      filterMode: FilterMode
-      search: String
-    ): AssessmentSubjectConnection
-    # Associated Activity
-    associatedActivity(id: ID!): AssociatedActivity
-    associatedActivities( 
-      first: Int
-      offset: Int
-      orderedBy: AssociatedActivityOrdering
-      orderMode: OrderingMode
-      filters: [AssociatedActivityFiltering]
-      filterMode: FilterMode
-      search: String
-    ): AssociatedActivityConnection
-    # Characterizations
-    characterization(id: ID!): Characterization
-    characterizations( 
-      first: Int
-      offset: Int
-      orderedBy: CharacterizationOrdering
-      orderMode: OrderingMode
-      filters: [CharacterizationFiltering]
-      filterMode: FilterMode
-      search: String
-    ): CharacterizationConnection
-    # Evidence
-    evidence(id: ID!): Evidence
-    evidenceList( 
-      first: Int
-      offset: Int
-      orderedBy: EvidenceOrdering
-      orderMode: OrderingMode
-      filters: [EvidenceFiltering]
-      filterMode: FilterMode
-      search: String
-    ): EvidenceConnection
-    # Facet
-    facet(id: ID!): Facet
-    facets( 
-      first: Int
-      offset: Int
-      orderedBy: FacetOrdering
-      orderMode: OrderingMode
-      filters: [FacetFiltering]
-      filterMode: FilterMode
-      search: String
-    ): FacetConnection
-    #Log Entry Author
-    logEntryAuthor(id: ID!): LogEntryAuthor
-    logEntryAuthors( 
-      first: Int
-      offset: Int
-      orderedBy: LogEntryAuthorOrdering
-      orderMode: OrderingMode
-      filters: [LogEntryAuthorFiltering]
-      filterMode: FilterMode
-      search: String
-    ): LogEntryAuthorConnection
-    #Mitigating Factor
-    mitigatingFactor(id: ID!): MitigatingFactor
-    mitigatingFactors( 
-      first: Int
-      offset: Int
-      orderedBy: MitigatingFactorOrdering
-      orderMode: OrderingMode
-      filters: [MitigatingFactorFiltering]
-      filterMode: FilterMode
-      search: String
-    ): MitigatingFactorConnection
-    # Observation
-    observation(id: ID!): Observation
-    observations( 
-      first: Int
-      offset: Int
-      orderedBy: ObservationsOrdering
-      orderMode: OrderingMode
-      filters: [ObservationsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): ObservationConnection
-    # Origin
-    origin(id: ID!): Origin
-    origins( 
-      first: Int
-      offset: Int
-      orderedBy: OriginOrdering
-      orderMode: OrderingMode
-      filters: [OriginFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OriginConnection
-    # Oscal Task
-    oscalTask(id: ID!): OscalTask
-    oscalTasks( 
-      first: Int
-      offset: Int
-      orderedBy: OscalTaskOrdering
-      orderMode: OrderingMode
-      filters: [OscalTaskFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalTaskConnection
-    # Required Asset
-    requiredAsset(id: ID!): RequiredAsset
-    requiredAssets( 
-      first: Int
-      offset: Int
-      orderedBy: RequiredAssetOrdering
-      orderMode: OrderingMode
-      filters: [RequiredAssetFiltering]
-      filterMode: FilterMode
-      search: String
-    ): RequiredAssetConnection
-    # Risk 
-    risk(id: ID!): Risk
-    risks( 
-      first: Int
-      offset: Int
-      orderedBy: RisksOrdering
-      orderMode: OrderingMode
-      filters: [RisksFiltering]
-      filterMode: FilterMode
-      search: String
-    ): RiskConnection
-    # Risk Log Entry
-    riskLogEntry(id: ID!): RiskLogEntry
-    riskLogEntries( 
-      first: Int
-      offset: Int
-      orderedBy: RiskLogEntriesOrdering
-      orderMode: OrderingMode
-      filters: [RiskLogEntriesFiltering]
-      filterMode: FilterMode
-      search: String
-    ): RiskLogEntryConnection
-    # Risk Response
-    riskResponse(id: ID!): RiskResponse
-    riskResponses( 
-      first: Int
-      offset: Int
-      orderedBy: RiskResponsesOrdering
-      orderMode: OrderingMode
-      filters: [RiskResponsesFiltering]
-      filterMode: FilterMode
-      search: String
-    ): RiskResponseConnection
-    # Subject
-    subject(id: ID!): Subject
-    subjects( 
-      first: Int
-      offset: Int
-      orderedBy: SubjectOrdering
-      orderMode: OrderingMode
-      filters: [SubjectFiltering]
-      filterMode: FilterMode
-      search: String
-    ): SubjectConnection
-  }
+# declares the query entry-points for this type
+extend type Query {
+  # Activity
+  activity(id: ID!): Activity
+  activities(
+    first: Int
+    offset: Int
+    orderedBy: ActivityOrdering
+    orderMode: OrderingMode
+    filters: [ActivityFiltering]
+    filterMode: FilterMode
+    search: String
+  ): ActivityConnection
+  # Actor
+  actor(id: ID!): Actor
+  actors(
+    first: Int
+    offset: Int
+    orderedBy: ActorOrdering
+    orderMode: OrderingMode
+    filters: [ActorFiltering]
+    filterMode: FilterMode
+    search: String
+  ): ActorConnection
+  # Assessment Log Entry
+  assessmentLogEntry(id: ID!): AssessmentLogEntry
+  assessmentLogEntries(
+    first: Int
+    offset: Int
+    orderedBy: AssessmentLogEntriesOrdering
+    orderMode: OrderingMode
+    filters: [AssessmentLogEntriesFiltering]
+    filterMode: FilterMode
+    search: String
+  ): AssessmentLogEntryConnection
+  # AssessmentAsset
+  assessmentAsset(id: ID!): AssessmentAsset
+  assessmentAssets(first: Int, offset: Int): AssessmentAssetConnection
+  # AssessmentPlatform
+  assessmentPlatform(id: ID!): AssessmentPlatform
+  assessmentPlatforms(
+    first: Int
+    offset: Int
+    orderedBy: AssessmentPlatformOrdering
+    orderMode: OrderingMode
+    filters: [AssessmentPlatformFiltering]
+    filterMode: FilterMode
+    search: String
+  ): AssessmentPlatformConnection
+  # AssessmentSubject
+  assessmentSubject(id: ID!): AssessmentSubject
+  assessmentSubjects(
+    first: Int
+    offset: Int
+    orderedBy: AssessmentSubjectOrdering
+    orderMode: OrderingMode
+    filters: [AssessmentSubjectFiltering]
+    filterMode: FilterMode
+    search: String
+  ): AssessmentSubjectConnection
+  # Associated Activity
+  associatedActivity(id: ID!): AssociatedActivity
+  associatedActivities(
+    first: Int
+    offset: Int
+    orderedBy: AssociatedActivityOrdering
+    orderMode: OrderingMode
+    filters: [AssociatedActivityFiltering]
+    filterMode: FilterMode
+    search: String
+  ): AssociatedActivityConnection
+  # Characterizations
+  characterization(id: ID!): Characterization
+  characterizations(
+    first: Int
+    offset: Int
+    orderedBy: CharacterizationOrdering
+    orderMode: OrderingMode
+    filters: [CharacterizationFiltering]
+    filterMode: FilterMode
+    search: String
+  ): CharacterizationConnection
+  # Evidence
+  evidence(id: ID!): Evidence
+  evidenceList(
+    first: Int
+    offset: Int
+    orderedBy: EvidenceOrdering
+    orderMode: OrderingMode
+    filters: [EvidenceFiltering]
+    filterMode: FilterMode
+    search: String
+  ): EvidenceConnection
+  # Facet
+  facet(id: ID!): Facet
+  facets(
+    first: Int
+    offset: Int
+    orderedBy: FacetOrdering
+    orderMode: OrderingMode
+    filters: [FacetFiltering]
+    filterMode: FilterMode
+    search: String
+  ): FacetConnection
+  #Log Entry Author
+  logEntryAuthor(id: ID!): LogEntryAuthor
+  logEntryAuthors(
+    first: Int
+    offset: Int
+    orderedBy: LogEntryAuthorOrdering
+    orderMode: OrderingMode
+    filters: [LogEntryAuthorFiltering]
+    filterMode: FilterMode
+    search: String
+  ): LogEntryAuthorConnection
+  #Mitigating Factor
+  mitigatingFactor(id: ID!): MitigatingFactor
+  mitigatingFactors(
+    first: Int
+    offset: Int
+    orderedBy: MitigatingFactorOrdering
+    orderMode: OrderingMode
+    filters: [MitigatingFactorFiltering]
+    filterMode: FilterMode
+    search: String
+  ): MitigatingFactorConnection
+  # Observation
+  observation(id: ID!): Observation
+  observations(
+    first: Int
+    offset: Int
+    orderedBy: ObservationsOrdering
+    orderMode: OrderingMode
+    filters: [ObservationsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): ObservationConnection
+  # Origin
+  origin(id: ID!): Origin
+  origins(
+    first: Int
+    offset: Int
+    orderedBy: OriginOrdering
+    orderMode: OrderingMode
+    filters: [OriginFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OriginConnection
+  # Oscal Task
+  oscalTask(id: ID!): OscalTask
+  oscalTasks(
+    first: Int
+    offset: Int
+    orderedBy: OscalTaskOrdering
+    orderMode: OrderingMode
+    filters: [OscalTaskFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalTaskConnection
+  # Required Asset
+  requiredAsset(id: ID!): RequiredAsset
+  requiredAssets(
+    first: Int
+    offset: Int
+    orderedBy: RequiredAssetOrdering
+    orderMode: OrderingMode
+    filters: [RequiredAssetFiltering]
+    filterMode: FilterMode
+    search: String
+  ): RequiredAssetConnection
+  # Risk
+  risk(id: ID!): Risk
+  risks(
+    first: Int
+    offset: Int
+    orderedBy: RisksOrdering
+    orderMode: OrderingMode
+    filters: [RisksFiltering]
+    filterMode: FilterMode
+    search: String
+  ): RiskConnection
+  # Risk Log Entry
+  riskLogEntry(id: ID!): RiskLogEntry
+  riskLogEntries(
+    first: Int
+    offset: Int
+    orderedBy: RiskLogEntriesOrdering
+    orderMode: OrderingMode
+    filters: [RiskLogEntriesFiltering]
+    filterMode: FilterMode
+    search: String
+  ): RiskLogEntryConnection
+  # Risk Response
+  riskResponse(id: ID!): RiskResponse
+  riskResponses(
+    first: Int
+    offset: Int
+    orderedBy: RiskResponsesOrdering
+    orderMode: OrderingMode
+    filters: [RiskResponsesFiltering]
+    filterMode: FilterMode
+    search: String
+  ): RiskResponseConnection
+  # Subject
+  subject(id: ID!): Subject
+  subjects(
+    first: Int
+    offset: Int
+    orderedBy: SubjectOrdering
+    orderMode: OrderingMode
+    filters: [SubjectFiltering]
+    filterMode: FilterMode
+    search: String
+  ): SubjectConnection
+}
 
-  # declares the mutation entry-points for this type
-  extend type Mutation {
-    # Activity
-    createActivity(input: ActivityAddInput): Activity
-    deleteActivity(id: ID!): String!
-    editActivity(id: ID!, input: [EditInput]!, commitMessage: String): Activity
-    # Actor
-    createActor(input: ActorAddInput): Actor
-    deleteActor(id: ID!): String!
-    editActor(id: ID!, input: [EditInput]!, commitMessage: String): Actor
-    # Assessment Log Entry
-    createAssessmentLogEntry(input: AssessmentLogEntryAddInput): AssessmentLogEntry
-    deleteAssessmentLogEntry(resultId: ID, id: ID!): String!
-    editAssessmentLogEntry(id: ID!, input: [EditInput]!, commitMessage: String): AssessmentLogEntry
-    # AssessmentPlatform
-    createAssessmentPlatform(input: AssessmentPlatformAddInput): AssessmentPlatform
-    deleteAssessmentPlatform(id: ID!): String!
-    editAssessmentPlatform(id: ID!, input: [EditInput]!, commitMessage: String): AssessmentPlatform
-    # AssessmentSubject
-    createAssessmentSubject(input: AssessmentSubjectAddInput): AssessmentSubject
-    deleteAssessmentSubject(id: ID!): String!
-    editAssessmentSubject(id: ID!, input: [EditInput]!, commitMessage: String): AssessmentSubject
-    # AssociatedActivity
-    createAssociatedActivity(input: AssociatedActivityAddInput): AssociatedActivity
-    deleteAssociatedActivity(taskId:, ID, id: ID!): String!
-    editAssociatedActivity(id: ID!, input: [EditInput]!, commitMessage: String): AssociatedActivity
-    # Characterization
-    createCharacterization(input: CharacterizationAddInput): Characterization
-    deleteCharacterization(riskId: ID!, id: ID!): String!
-    editCharacterization(id: ID!, input: [EditInput]!, commitMessage: String): Characterization
-    # Evidence
-    createEvidence( input: EvidenceAddInput): Evidence
-    deleteEvidence( observationId: ID, id: ID!): String!
-    editEvidence(id: ID!, input: [EditInput]!, commitMessage: String): Evidence
-    # Facet
-    createFacet(input: FacetAddInput): Facet
-    deleteFacet(characterizationId: ID, id: ID!): String!
-    editFacet(id: ID!, input: [EditInput]!, commitMessage: String): Facet
-    # Mitigating Factor
-    createMitigatingFactor(input: MitigatingFactorAddInput): MitigatingFactor
-    deleteMitigatingFactor(riskId: ID, id: ID!): String!
-    editMitigatingFactor(id: ID!, input: [EditInput]!, commitMessage: String): MitigatingFactor
-    # Observation
-    createObservation(poamId: ID, resultId: ID, input: ObservationAddInput): Observation
-    deleteObservation(poamId: ID, resultId: ID, id: ID!): String!
-    editObservation(id: ID!, input: [EditInput]!, commitMessage: String): Observation
-    # Origins
-    createOrigin(input: OriginAddInput): Origin
-    deleteOrigin(id: ID!): String!
-    editOrigin(id: ID!, input: [EditInput]!, commitMessage: String): Origin
-    # Oscal Task
-    createOscalTask(input: OscalTaskAddInput): OscalTask
-    deleteOscalTask(id: ID!): String!
-    editOscalTask(id: ID!, input: [EditInput]!, commitMessage: String): OscalTask
-    # RequiredAsset
-    createRequiredAsset(input: RequiredAssetAddInput): RequiredAsset
-    deleteRequiredAsset(remediationId: ID, id: ID!): String!
-    editRequiredAsset(id: ID!, input: [EditInput]!, commitMessage: String): RequiredAsset
-    # RiskLog Entry
-    createRiskLogEntry(input: RiskLogEntryAddInput): RiskLogEntry
-    deleteRiskLogEntry(riskId: ID, id: ID!): String!
-    editRiskLogEntry(id: ID!, input: [EditInput]!, commitMessage: String): RiskLogEntry
-    # Risk 
-    createRisk(poamId: ID, resultId: ID, input: RiskAddInput): Risk
-    deleteRisk(poamId: ID, resultId: ID, id: ID!): String!
-    editRisk(id: ID!, input: [EditInput]!, commitMessage: String): Risk
-    # Risk Response
-    createRiskResponse(input: RiskResponseAddInput): RiskResponse
-    deleteRiskResponse(riskId: ID!, id: ID!): String!
-    editRiskResponse(id: ID!, input: [EditInput]!, commitMessage: String): RiskResponse
-    # Subject
-    createSubject(input: SubjectAddInput): Subject
-    deleteSubject(id: ID!): String!
-    editSubject(id: ID!, input: [EditInput]!, commitMessage: String): Subject
-  }
+# declares the mutation entry-points for this type
+extend type Mutation {
+  # Activity
+  createActivity(input: ActivityAddInput): Activity
+  deleteActivity(id: ID!): String!
+  editActivity(id: ID!, input: [EditInput]!, commitMessage: String): Activity
+  # Actor
+  createActor(input: ActorAddInput): Actor
+  deleteActor(id: ID!): String!
+  editActor(id: ID!, input: [EditInput]!, commitMessage: String): Actor
+  # Assessment Log Entry
+  createAssessmentLogEntry(
+    input: AssessmentLogEntryAddInput
+  ): AssessmentLogEntry
+  deleteAssessmentLogEntry(resultId: ID, id: ID!): String!
+  editAssessmentLogEntry(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): AssessmentLogEntry
+  # AssessmentPlatform
+  createAssessmentPlatform(
+    input: AssessmentPlatformAddInput
+  ): AssessmentPlatform
+  deleteAssessmentPlatform(id: ID!): String!
+  editAssessmentPlatform(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): AssessmentPlatform
+  # AssessmentSubject
+  createAssessmentSubject(input: AssessmentSubjectAddInput): AssessmentSubject
+  deleteAssessmentSubject(id: ID!): String!
+  editAssessmentSubject(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): AssessmentSubject
+  # AssociatedActivity
+  createAssociatedActivity(
+    input: AssociatedActivityAddInput
+  ): AssociatedActivity
+  deleteAssociatedActivity(taskId: ID, id: ID!): String!
+  editAssociatedActivity(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): AssociatedActivity
+  # Characterization
+  createCharacterization(input: CharacterizationAddInput): Characterization
+  deleteCharacterization(riskId: ID!, id: ID!): String!
+  editCharacterization(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): Characterization
+  # Evidence
+  createEvidence(input: EvidenceAddInput): Evidence
+  deleteEvidence(observationId: ID, id: ID!): String!
+  editEvidence(id: ID!, input: [EditInput]!, commitMessage: String): Evidence
+  # Facet
+  createFacet(input: FacetAddInput): Facet
+  deleteFacet(characterizationId: ID, id: ID!): String!
+  editFacet(id: ID!, input: [EditInput]!, commitMessage: String): Facet
+  # Mitigating Factor
+  createMitigatingFactor(input: MitigatingFactorAddInput): MitigatingFactor
+  deleteMitigatingFactor(riskId: ID, id: ID!): String!
+  editMitigatingFactor(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): MitigatingFactor
+  # Observation
+  createObservation(
+    poamId: ID
+    resultId: ID
+    input: ObservationAddInput
+  ): Observation
+  deleteObservation(poamId: ID, resultId: ID, id: ID!): String!
+  editObservation(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): Observation
+  # Origins
+  createOrigin(input: OriginAddInput): Origin
+  deleteOrigin(id: ID!): String!
+  editOrigin(id: ID!, input: [EditInput]!, commitMessage: String): Origin
+  # Oscal Task
+  createOscalTask(input: OscalTaskAddInput): OscalTask
+  deleteOscalTask(id: ID!): String!
+  editOscalTask(id: ID!, input: [EditInput]!, commitMessage: String): OscalTask
+  # RequiredAsset
+  createRequiredAsset(input: RequiredAssetAddInput): RequiredAsset
+  deleteRequiredAsset(remediationId: ID, id: ID!): String!
+  editRequiredAsset(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): RequiredAsset
+  # RiskLog Entry
+  createRiskLogEntry(input: RiskLogEntryAddInput): RiskLogEntry
+  deleteRiskLogEntry(riskId: ID, id: ID!): String!
+  editRiskLogEntry(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): RiskLogEntry
+  # Risk
+  createRisk(poamId: ID, resultId: ID, input: RiskAddInput): Risk
+  deleteRisk(poamId: ID, resultId: ID, id: ID!): String!
+  editRisk(id: ID!, input: [EditInput]!, commitMessage: String): Risk
+  # Risk Response
+  createRiskResponse(input: RiskResponseAddInput): RiskResponse
+  deleteRiskResponse(riskId: ID!, id: ID!): String!
+  editRiskResponse(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): RiskResponse
+  # Subject
+  createSubject(input: SubjectAddInput): Subject
+  deleteSubject(id: ID!): String!
+  editSubject(id: ID!, input: [EditInput]!, commitMessage: String): Subject
+}
 
 ## Activity
 #
-  "Defines identifying information about an assessment or related process that can be performed. In the assessment plan, this is an intended activity which may be associated with an assessment task. In the assessment results, this an activity that was actually performed as part of an assessment."
-  type Activity implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Activity
-    "Identifies the name for the activity."
-    name: String!
-    "Identifies a human-readable description of the activity."
-    description: String
-    "Identifies the assessment method used."
-    methods: [MethodTypes!]!
-    # "Identifies one or more steps related to an activity."
-    # steps: [Step]
-    # "Identifies the optional set of controls and control objectives that are assessed or remediated by this activity."
-    # related_controls: [ControlReview]
-    "Identifies the person or organization responsible for performing a specific role related to the task."
-    responsible_roles: [OscalResponsibleParty]
-  }
-  input ActivityAddInput {
-    "Identifies the name for the Activity."
-    name: String!
-    "Identifies a human-readable description of the activity."
-    description: String!
-    "Identifies the assessment method used."
-    methods: [MethodTypes!]!
-    # "Identifies the optional set of controls and control objectives that are assessed or remediated by this activity."
-    # related_controls: [ControlReview]
-    "Identifies the person or organization responsible for performing a specific role related to the task."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-  }
-  # Ordering Types
-  enum ActivityOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Method"
-    method
-  }
-  # Filtering types
-  input ActivityFiltering {
-    key: ActivityFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about an assessment or related process that can be performed. In the assessment plan, this is an intended activity which may be associated with an assessment task. In the assessment results, this an activity that was actually performed as part of an assessment."
+type Activity implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum ActivityFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Method"
-    method
-  }
-  # Pagination Types
-  type ActivityConnection {
-    pageInfo: PageInfo!
-    edges: [ActivityEdge]
-  }
-  type ActivityEdge {
-    cursor: String!
-    node: Activity!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Activity
+  "Identifies the name for the activity."
+  name: String!
+  "Identifies a human-readable description of the activity."
+  description: String
+  "Identifies the assessment method used."
+  methods: [MethodTypes!]!
+  # "Identifies one or more steps related to an activity."
+  # steps: [Step]
+  # "Identifies the optional set of controls and control objectives that are assessed or remediated by this activity."
+  # related_controls: [ControlReview]
+  "Identifies the person or organization responsible for performing a specific role related to the task."
+  responsible_roles: [OscalResponsibleParty]
+}
+input ActivityAddInput {
+  "Identifies the name for the Activity."
+  name: String!
+  "Identifies a human-readable description of the activity."
+  description: String!
+  "Identifies the assessment method used."
+  methods: [MethodTypes!]!
+  # "Identifies the optional set of controls and control objectives that are assessed or remediated by this activity."
+  # related_controls: [ControlReview]
+  "Identifies the person or organization responsible for performing a specific role related to the task."
+  responsible_roles: [OscalResponsibleRoleAddInput]
+}
+# Ordering Types
+enum ActivityOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Method"
+  method
+  "Marking"
+  marking
+}
+# Filtering types
+input ActivityFiltering {
+  key: ActivityFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum ActivityFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Method"
+  method
+}
+# Pagination Types
+type ActivityConnection {
+  pageInfo: PageInfo!
+  edges: [ActivityEdge]
+}
+type ActivityEdge {
+  cursor: String!
+  node: Activity!
+}
 
 ## Actor
 #
-  "Defines identifying information about an actor that produces an observation, a finding, or a risk."
-  type Actor {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the kind of actor"
-    actor_type: ActorType!
-    "Identifies a reference to the tool or person based on the associated type."
-    actor_ref: ActorTarget!
-    "For a party, this can optionally be used to specify the role the actor was performing."
-    role_ref: OscalRole
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-  }
-  input ActorAddInput {
-    "Identifies the kind of actor"
-    actor_type: ActorType!
-    "Identifies a reference to the tool or person based on the associated type."
-    actor_ref: ID!
-    "For a party, this can optionally be used to specify the role the actor was performing."
-    role_ref: ID
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReferenceAddInput]
-  }
-  # Ordering Types
-  enum ActorOrdering {
-    "Actor Type"
-    actor_type
-  }
-  # Filtering Types
-  input ActorFiltering {
-    key: ActorFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum ActorFilter {
-    "Actor Type"
-    actor_type
-  }
-  # Pagination Types
-  type ActorConnection {
-    pageInfo: PageInfo!
-    edges: [ActorEdge]
-  }
-  type ActorEdge {
-    cursor: String!
-    node: Actor!
-  }
+"Defines identifying information about an actor that produces an observation, a finding, or a risk."
+type Actor {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the kind of actor"
+  actor_type: ActorType!
+  "Identifies a reference to the tool or person based on the associated type."
+  actor_ref: ActorTarget!
+  "For a party, this can optionally be used to specify the role the actor was performing."
+  role_ref: OscalRole
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+}
+input ActorAddInput {
+  "Identifies the kind of actor"
+  actor_type: ActorType!
+  "Identifies a reference to the tool or person based on the associated type."
+  actor_ref: ID!
+  "For a party, this can optionally be used to specify the role the actor was performing."
+  role_ref: ID
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReferenceAddInput]
+}
+# Ordering Types
+enum ActorOrdering {
+  "Actor Type"
+  actor_type
+}
+# Filtering Types
+input ActorFiltering {
+  key: ActorFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum ActorFilter {
+  "Actor Type"
+  actor_type
+}
+# Pagination Types
+type ActorConnection {
+  pageInfo: PageInfo!
+  edges: [ActorEdge]
+}
+type ActorEdge {
+  cursor: String!
+  node: Actor!
+}
 
 ## Assessment Assets
 "Defines identifying information about assets used in performing the assessment. "
@@ -501,7 +550,7 @@ type AssessmentPlatform implements BasicObject & LifecycleObject & OscalObject {
     orderMode: OrderingMode
     filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-    search: String 
+    search: String
   ): OscalRelationshipConnection
   "Identifies the name for the Activity."
   name: String!
@@ -518,473 +567,479 @@ input AssessmentPlatformAddInput {
   "Identifies the set of components that are used by the assessment platform"
   uses_components: [ID]
 }
-  # Ordering Types
-  enum AssessmentPlatformOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Filtering Types
-  input AssessmentPlatformFiltering {
-    key: AssessmentPlatformFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum AssessmentPlatformFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Pagination Types
-  type AssessmentPlatformConnection {
-    pageInfo: PageInfo!
-    edges: [AssessmentPlatformEdge]
-  }
-  type AssessmentPlatformEdge {
-    cursor: String!
-    node: AssessmentPlatform!
-  }
+# Ordering Types
+enum AssessmentPlatformOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Marking"
+  marking
+}
+# Filtering Types
+input AssessmentPlatformFiltering {
+  key: AssessmentPlatformFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum AssessmentPlatformFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+}
+# Pagination Types
+type AssessmentPlatformConnection {
+  pageInfo: PageInfo!
+  edges: [AssessmentPlatformEdge]
+}
+type AssessmentPlatformEdge {
+  cursor: String!
+  node: AssessmentPlatform!
+}
 
 ## AssessmentSubject
 #
-  "Defines the identifying information about the system elements being assessed, such as components, inventory items, and locations. In the assessment plan, this identifies a planned assessment subject. In the assessment results this is an actual assessment subject, and reflects any changes from the plan. exactly what will be the focus of this assessment. Any subjects not identified in this way are out-of-scope."
-  type AssessmentSubject {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement."
-    subject_type: SubjectType!
-    "Identifies a human-readable description of the collection of subjects being included in this assessment."
-    description: String
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Indicates to include all subjects."
-    include_all: Boolean!
-    "Identifies a set of assessment subjects to include"
-    include_subjects: [Subject]
-    "Identifies a set of assessment subjects to exclude"
-    exclude_subjects: [Subject]
-  }
-  input AssessmentSubjectAddInput {
-    "Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement."
-    subject_type: SubjectType!
-    "Indicates to include all subjects."
-    include_all: Boolean
-    "Identifies a set of assessment subjects to include"
-    include_subjects: [SubjectAddInput]
-    "Identifies a set of assessment subjects to exclude"
-    exclude_subjects: [SubjectAddInput]
-  }
-    # Ordering Types
-  enum AssessmentSubjectOrdering {
-    "Subject Type"
-    subject_type
-  }
-  # Filtering
-  input AssessmentSubjectFiltering {
-    key: AssessmentSubjectFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum AssessmentSubjectFilter {
-    "Subject Type"
-    subject_type
-  }
-  # Pagination Types
-  type AssessmentSubjectConnection {
-    pageInfo: PageInfo!
-    edges: [AssessmentSubjectEdge]
-  }
-  type AssessmentSubjectEdge {
-    cursor: String!
-    node: AssessmentSubject!
-  }
+"Defines the identifying information about the system elements being assessed, such as components, inventory items, and locations. In the assessment plan, this identifies a planned assessment subject. In the assessment results this is an actual assessment subject, and reflects any changes from the plan. exactly what will be the focus of this assessment. Any subjects not identified in this way are out-of-scope."
+type AssessmentSubject {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement."
+  subject_type: SubjectType!
+  "Identifies a human-readable description of the collection of subjects being included in this assessment."
+  description: String
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Indicates to include all subjects."
+  include_all: Boolean!
+  "Identifies a set of assessment subjects to include"
+  include_subjects: [Subject]
+  "Identifies a set of assessment subjects to exclude"
+  exclude_subjects: [Subject]
+}
+input AssessmentSubjectAddInput {
+  "Indicates the type of assessment subject, such as a component, inventory, item, location, or party represented by this selection statement."
+  subject_type: SubjectType!
+  "Indicates to include all subjects."
+  include_all: Boolean
+  "Identifies a set of assessment subjects to include"
+  include_subjects: [SubjectAddInput]
+  "Identifies a set of assessment subjects to exclude"
+  exclude_subjects: [SubjectAddInput]
+}
+# Ordering Types
+enum AssessmentSubjectOrdering {
+  "Subject Type"
+  subject_type
+}
+# Filtering
+input AssessmentSubjectFiltering {
+  key: AssessmentSubjectFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum AssessmentSubjectFilter {
+  "Subject Type"
+  subject_type
+}
+# Pagination Types
+type AssessmentSubjectConnection {
+  pageInfo: PageInfo!
+  edges: [AssessmentSubjectEdge]
+}
+type AssessmentSubjectEdge {
+  cursor: String!
+  node: AssessmentSubject!
+}
 
 ## AssociatedActivity
 #
-  "Defines identifying information about an activity to be performed as part of a task."
-  type AssociatedActivity {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies a references to an activity defined in the list of activities."
-    activity_id: Activity
-    "Identifies the person or organization responsible for performing a specific role related to the task."
-    responsible_roles: [OscalResponsibleParty]
-    "Identifies an include/exclude pair starts with processing the include, then removing matching entries in the exclude."
-    subjects: [AssessmentSubject]
-  }
-  input AssociatedActivityAddInput {
-    "Identifies a references to an activity defined in the list of activities."
-    activity_id: ID!
-    "Identifies a reference to a task for which the activity is associated, so that it can be attached."
-    task_id: ID
-    "Identifies the person or organization responsible for performing a specific role related to the task."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies an include/exclude pair starts with processing the include, then removing matching entries in the exclude."
-    subjects: [AssessmentSubjectAddInput]
-  }
-  # Ordering Types
-  enum AssociatedActivityOrdering {
-    "Activity ID"
-    activity_id
-  }
-  # Filtering
-  input AssociatedActivityFiltering {
-    key: AssociatedActivityFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum AssociatedActivityFilter {
-    "Activity ID"
-    activity_id
-  }
-  # Pagination Types
-  type AssociatedActivityConnection {
-    pageInfo: PageInfo!
-    edges: [AssociatedActivityEdge]
-  }
-  type AssociatedActivityEdge {
-    cursor: String!
-    node: AssociatedActivity!
-  }
+"Defines identifying information about an activity to be performed as part of a task."
+type AssociatedActivity {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies a references to an activity defined in the list of activities."
+  activity_id: Activity
+  "Identifies the person or organization responsible for performing a specific role related to the task."
+  responsible_roles: [OscalResponsibleParty]
+  "Identifies an include/exclude pair starts with processing the include, then removing matching entries in the exclude."
+  subjects: [AssessmentSubject]
+}
+input AssociatedActivityAddInput {
+  "Identifies a references to an activity defined in the list of activities."
+  activity_id: ID!
+  "Identifies a reference to a task for which the activity is associated, so that it can be attached."
+  task_id: ID
+  "Identifies the person or organization responsible for performing a specific role related to the task."
+  responsible_roles: [OscalResponsibleRoleAddInput]
+  "Identifies an include/exclude pair starts with processing the include, then removing matching entries in the exclude."
+  subjects: [AssessmentSubjectAddInput]
+}
+# Ordering Types
+enum AssociatedActivityOrdering {
+  "Activity ID"
+  activity_id
+}
+# Filtering
+input AssociatedActivityFiltering {
+  key: AssociatedActivityFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum AssociatedActivityFilter {
+  "Activity ID"
+  activity_id
+}
+# Pagination Types
+type AssociatedActivityConnection {
+  pageInfo: PageInfo!
+  edges: [AssociatedActivityEdge]
+}
+type AssociatedActivityEdge {
+  cursor: String!
+  node: AssociatedActivity!
+}
 
 ## Characterization
 #
-  "Defines identifying information about a characterization of risk."
-  type Characterization {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # Characterization
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies a reference to tool that performed the detection."
-    origins: [Origin]
-    "Identifies one or more individual characteristic that is part of a larger set produced by the same actor."
-    facets: [Facet]
-  }
-  input CharacterizationAddInput {
-    "Identifies a reference to the Risk for which this is a characterization so that it can be attached."
-    risk_id: ID!
-    "Identifies a reference to tool that performed the detection."
-    origins: [OriginAddInput]
-    "Identifies one or more individual characteristic that is part of a larger set produced by the same actor."
-    facets: [FacetAddInput]
-  }
-  # Ordering Types
-  enum CharacterizationOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Source"
-    origin_name
-  }
-  # Filtering Types
-  input CharacterizationFiltering {
-    key: CharacterizationFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum CharacterizationFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Source"
-    origin_name
-  }
-  # Pagination Types
-  type CharacterizationConnection {
-    pageInfo: PageInfo!
-    edges: [CharacterizationEdge]
-  }
-  type CharacterizationEdge {
-    cursor: String!
-    node: Characterization!
-  }
+"Defines identifying information about a characterization of risk."
+type Characterization {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # Characterization
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies a reference to tool that performed the detection."
+  origins: [Origin]
+  "Identifies one or more individual characteristic that is part of a larger set produced by the same actor."
+  facets: [Facet]
+}
+input CharacterizationAddInput {
+  "Identifies a reference to the Risk for which this is a characterization so that it can be attached."
+  risk_id: ID!
+  "Identifies a reference to tool that performed the detection."
+  origins: [OriginAddInput]
+  "Identifies one or more individual characteristic that is part of a larger set produced by the same actor."
+  facets: [FacetAddInput]
+}
+# Ordering Types
+enum CharacterizationOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Source"
+  origin_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input CharacterizationFiltering {
+  key: CharacterizationFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum CharacterizationFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Source"
+  origin_name
+}
+# Pagination Types
+type CharacterizationConnection {
+  pageInfo: PageInfo!
+  edges: [CharacterizationEdge]
+}
+type CharacterizationEdge {
+  cursor: String!
+  node: Characterization!
+}
 
 ## EventTiming
 #
-  union EventTiming = DateRangeTiming | OnDateTiming | FrequencyTiming
-  input EventTimingAddInput {
-    on_date: OnDateTimingAddInput
-    within_date_range: DateRangeTimingAddInput
-    at_frequency: FrequencyTimingAddInput
-  }
+union EventTiming = DateRangeTiming | OnDateTiming | FrequencyTiming
+input EventTimingAddInput {
+  on_date: OnDateTimingAddInput
+  within_date_range: DateRangeTimingAddInput
+  at_frequency: FrequencyTimingAddInput
+}
 ## DateRangeTiming
 #
-  "Defines identifying information about an Event Timing that occurs within a date range."
-  type DateRangeTiming {
-    "Identifies the specified date that the task must occur on or after."
-    start_date: Timestamp!
-    "identifies the specific date that the task must occur on or before."
-    end_date: Timestamp
-  }
-  input DateRangeTimingAddInput {
-    "Identifies the specified date that the task must occur on or after."
-    start_date: Timestamp!
-    "identifies the specific date that the task must occur on or before."
-    end_date: Timestamp
-  }
+"Defines identifying information about an Event Timing that occurs within a date range."
+type DateRangeTiming {
+  "Identifies the specified date that the task must occur on or after."
+  start_date: Timestamp!
+  "identifies the specific date that the task must occur on or before."
+  end_date: Timestamp
+}
+input DateRangeTimingAddInput {
+  "Identifies the specified date that the task must occur on or after."
+  start_date: Timestamp!
+  "identifies the specific date that the task must occur on or before."
+  end_date: Timestamp
+}
 ## FrequencyTiming
 #
-  "Defines identifying information abotu an Event Timing that occurs at a specified frequence"
-  type FrequencyTiming {
-    "Identifies the specified period of time that must elapse before the task must occur."
-    period: Int!
-    "Identifies the unit of time for the period"
-    unit: TimeUnit!
-  }
-  input FrequencyTimingAddInput {
-    "Identifies the specified period of time that must elapse before the task must occur."
-    period: Int!
-    "Identifies the unit of time for the period"
-    unit: TimeUnit!
-  }
+"Defines identifying information abotu an Event Timing that occurs at a specified frequence"
+type FrequencyTiming {
+  "Identifies the specified period of time that must elapse before the task must occur."
+  period: Int!
+  "Identifies the unit of time for the period"
+  unit: TimeUnit!
+}
+input FrequencyTimingAddInput {
+  "Identifies the specified period of time that must elapse before the task must occur."
+  period: Int!
+  "Identifies the unit of time for the period"
+  unit: TimeUnit!
+}
 ## OnDateTiming
 #
-  "Defines identifying information about an Event Timing that occur on a specific date."
-  type OnDateTiming {
-    "Identifies the date that the task must occur on."
-    on_date: Timestamp!
-  }
-  input OnDateTimingAddInput {
-    date: Timestamp!
-  }
+"Defines identifying information about an Event Timing that occur on a specific date."
+type OnDateTiming {
+  "Identifies the date that the task must occur on."
+  on_date: Timestamp!
+}
+input OnDateTimingAddInput {
+  date: Timestamp!
+}
 
 ## Evidence
 #
-  "Defines identifying information about evidence relevant to this observation."
-  type Evidence {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a resolvable URL reference to the relevant evidence."
-    href: URL
-    "Identifies a human-readable description of the evidence."
-    description: String
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-  }
-  input EvidenceAddInput {
-    "Identifies a reference to the Observation to which this evidence is to be attached."
-    observation_id: ID
-    "Identifies a resolvable URL reference to the relevant evidence."
-    href: URL
-    "Identifies a human-readable description of the evidence."
-    description: String
-  }
-  # Ordering Types
-  enum EvidenceOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Filtering Types
-  input EvidenceFiltering {
-    key: EvidenceFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum EvidenceFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Pagination Types
-  type EvidenceConnection {
-    pageInfo: PageInfo!
-    edges: [EvidenceEdge]
-  }
-  type EvidenceEdge {
-    cursor: String!
-    node: Evidence!
-  }
+"Defines identifying information about evidence relevant to this observation."
+type Evidence {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a resolvable URL reference to the relevant evidence."
+  href: URL
+  "Identifies a human-readable description of the evidence."
+  description: String
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+}
+input EvidenceAddInput {
+  "Identifies a reference to the Observation to which this evidence is to be attached."
+  observation_id: ID
+  "Identifies a resolvable URL reference to the relevant evidence."
+  href: URL
+  "Identifies a human-readable description of the evidence."
+  description: String
+}
+# Ordering Types
+enum EvidenceOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input EvidenceFiltering {
+  key: EvidenceFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum EvidenceFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+}
+# Pagination Types
+type EvidenceConnection {
+  pageInfo: PageInfo!
+  edges: [EvidenceEdge]
+}
+type EvidenceEdge {
+  cursor: String!
+  node: Evidence!
+}
 
 ## Facet
 #
-  "Defines the basic interface of a facet."
-  type Facet {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk)."
-    risk_state: RiskState!
-    "Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties."
-    source_system: URL!
-    "Identifies the name of the metric within the specified system."
-    facet_name: String!
-    "Indicates the value of the facet."
-    facet_value: String!
-  }
-  input FacetAddInput {
-    "Identifies a reference to the Risk Characterization on which this facet is to be attached."
-    characterization_id: ID
-    "Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk)."
-    risk_state: RiskState!
-    "Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties."
-    source_system: URL!
-    "Identifies the name of the metric within the specified system."
-    facet_name: String!
-    "Indicates the value of the facet."
-    facet_value: String!
-  }
-  # Ordering Types
-  enum FacetOrdering {
-    "Risk State"
-    risk_state
-    "Source System"
-    source_system
-    "Facet Name"
-    facet_name
-  }
-  # Filtering Types
-  input FacetFiltering {
-    key: FacetFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum FacetFilter {
-    "Risk State"
-    risk_state
-    "Source System"
-    source_system
-    "Facet Name"
-    facet_name
-  }
-  # Pagination Types
-  type FacetConnection {
-    pageInfo: PageInfo!
-    edges: [FacetEdge]
-  }
-  type FacetEdge {
-    cursor: String!
-    node: Facet!
-  }
+"Defines the basic interface of a facet."
+type Facet {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk)."
+  risk_state: RiskState!
+  "Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties."
+  source_system: URL!
+  "Identifies the name of the metric within the specified system."
+  facet_name: String!
+  "Indicates the value of the facet."
+  facet_value: String!
+}
+input FacetAddInput {
+  "Identifies a reference to the Risk Characterization on which this facet is to be attached."
+  characterization_id: ID
+  "Indicates if the facet is 'initial' as first identified, or 'adjusted' indicating that the value has be changed after some adjustments have been made (e.g., to identify residual risk)."
+  risk_state: RiskState!
+  "Specifies the naming system under which this risk metric is organized, which allows for the same names to be used in different systems controlled by different parties."
+  source_system: URL!
+  "Identifies the name of the metric within the specified system."
+  facet_name: String!
+  "Indicates the value of the facet."
+  facet_value: String!
+}
+# Ordering Types
+enum FacetOrdering {
+  "Risk State"
+  risk_state
+  "Source System"
+  source_system
+  "Facet Name"
+  facet_name
+}
+# Filtering Types
+input FacetFiltering {
+  key: FacetFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum FacetFilter {
+  "Risk State"
+  risk_state
+  "Source System"
+  source_system
+  "Facet Name"
+  facet_name
+}
+# Pagination Types
+type FacetConnection {
+  pageInfo: PageInfo!
+  edges: [FacetEdge]
+}
+type FacetEdge {
+  cursor: String!
+  node: Facet!
+}
 
 ## Finding Target
 #
-  "Defines identifying information about the target of a finding."
-  type FindingTarget {
-    # "Identifies the type of the finding target."
-    # target_type: FindingTargetType!
-    # "Identifies the specific target."
-    # target: StatementOrObjective!
-    "Identifies a name for this objective status."
-    name: String
-    "Identifies a human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied."
-    description: String
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies whether the objective is satisfied or not within a given system."
-    objective_status_state: ObjectiveStatusState!
-    "Identifies the reason the objective was given it's status."
-    objective_status_reason: ObjectiveStatusReason
-    "Identifies an explanation as to why the objective was not satisfied."
-    objective_status_explanation: String
-    "Indicates the degree to which the given control was implemented."
-    implementation_status: ImplementationStatus
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-  }
+"Defines identifying information about the target of a finding."
+type FindingTarget {
+  # "Identifies the type of the finding target."
+  # target_type: FindingTargetType!
+  # "Identifies the specific target."
+  # target: StatementOrObjective!
+  "Identifies a name for this objective status."
+  name: String
+  "Identifies a human-readable description of the assessor's conclusions regarding the degree to which an objective is satisfied."
+  description: String
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies whether the objective is satisfied or not within a given system."
+  objective_status_state: ObjectiveStatusState!
+  "Identifies the reason the objective was given it's status."
+  objective_status_reason: ObjectiveStatusReason
+  "Identifies an explanation as to why the objective was not satisfied."
+  objective_status_explanation: String
+  "Indicates the degree to which the given control was implemented."
+  implementation_status: ImplementationStatus
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+}
 
 ## LogEntry
 #
 "Defines an abstract interface for identifying information about a log entry for actions taken."
 interface LogEntry {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # LogEntry
-    "Identifies the name for the risk log entry."
-    name: String!
-    "Identifies a human-readable description of of what was done regarding the risk."
-    description: String!
-    "Identifies the start date and time of the event."
-    event_start: Timestamp
-    "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
-    event_end: Timestamp
-    "Used to indicate who created a log entry in what role."
-    logged_by: [LogEntryAuthor]
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+  # LogEntry
+  "Identifies the name for the risk log entry."
+  name: String!
+  "Identifies a human-readable description of of what was done regarding the risk."
+  description: String!
+  "Identifies the start date and time of the event."
+  event_start: Timestamp
+  "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
+  event_end: Timestamp
+  "Used to indicate who created a log entry in what role."
+  logged_by: [LogEntryAuthor]
 }
 
 ## LogEntryAuthor
@@ -999,7 +1054,7 @@ type LogEntryAuthor {
   "Identifies a reference to the role in which the party is making the log entry"
   role: OscalRole
 }
-input LogEntryAuthorAddInput  {
+input LogEntryAuthorAddInput {
   "Identifier reference to the party who is making the log entry."
   party: ID!
   "Identifies a reference to the role in which the party is making the log entry"
@@ -1011,6 +1066,8 @@ enum LogEntryAuthorOrdering {
   party_name
   "Role"
   role_identifier
+  "Marking"
+  marking
 }
 # Filtering Types
 enum LogEntryAuthorFilter {
@@ -1036,506 +1093,513 @@ type LogEntryAuthorEdge {
   node: LogEntryAuthor!
 }
 
-
 ## Assessment Log Entry
 #
-  "Defines identifying information about a log entry of all assessment-related actions taken."
-  type AssessmentLogEntry implements BasicObject & LifecycleObject & OscalObject & LogEntry {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # LogEntry
-    "Identifies the name for the risk log entry."
-    name: String!
-    "Identifies a human-readable description of of what was done regarding the risk."
-    description: String!
-    "Identifies the start date and time of the event."
-    event_start: Timestamp!
-    "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
-    event_end: Timestamp
-    "Used to indicate who created a log entry in what role."
-    logged_by: [LogEntryAuthor]
-    "Identifies one or more task for which the containing object is a consequence of."
-    related_tasks: [OscalTask]
-  }
-  "Defines identifying information about a log entry of all assessment-related actions taken."
-  input AssessmentLogEntryAddInput  {
-    "Indentifies a reference to the Result for which this is a log entry so that it can be attached."
-    result_id: ID
-    # Entry
-    "Identifies the name for the risk log entry."
-    name: String!
-    "Identifies a human-readable description of of what was done regarding the risk."
-    description: String!
-    "Identifies the start date and time of the event."
-    event_start: Timestamp!
-    "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
-    event_end: Timestamp
-    "Used to indicate the party that created a log entry in what role."
-    logged_by: [LogEntryAuthorAddInput]
-  }
-  # Ordering Type
-  enum AssessmentLogEntriesOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Event Start"
-    event_start
-    "Event End"
-    event_end
-    "Name"
-    name
-  }
-  # Filtering Types
-  input AssessmentLogEntriesFiltering {
-    key: AssessmentLogEntriesFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a log entry of all assessment-related actions taken."
+type AssessmentLogEntry implements BasicObject & LifecycleObject & OscalObject & LogEntry {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum AssessmentLogEntriesFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Event Start"
-    event_start
-    "Event End"
-    event_end
-    "Name"
-    name
-  }
-  # Pagination Types
-  type AssessmentLogEntryConnection {
-    pageInfo: PageInfo!
-    edges: [AssessmentLogEntryEdge]
-  }
-  type AssessmentLogEntryEdge {
-    cursor: String!
-    node: AssessmentLogEntry!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # LogEntry
+  "Identifies the name for the risk log entry."
+  name: String!
+  "Identifies a human-readable description of of what was done regarding the risk."
+  description: String!
+  "Identifies the start date and time of the event."
+  event_start: Timestamp!
+  "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
+  event_end: Timestamp
+  "Used to indicate who created a log entry in what role."
+  logged_by: [LogEntryAuthor]
+  "Identifies one or more task for which the containing object is a consequence of."
+  related_tasks: [OscalTask]
+}
+"Defines identifying information about a log entry of all assessment-related actions taken."
+input AssessmentLogEntryAddInput {
+  "Indentifies a reference to the Result for which this is a log entry so that it can be attached."
+  result_id: ID
+  # Entry
+  "Identifies the name for the risk log entry."
+  name: String!
+  "Identifies a human-readable description of of what was done regarding the risk."
+  description: String!
+  "Identifies the start date and time of the event."
+  event_start: Timestamp!
+  "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
+  event_end: Timestamp
+  "Used to indicate the party that created a log entry in what role."
+  logged_by: [LogEntryAuthorAddInput]
+}
+# Ordering Type
+enum AssessmentLogEntriesOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Event Start"
+  event_start
+  "Event End"
+  event_end
+  "Name"
+  name
+  "Marking"
+  marking
+}
+# Filtering Types
+input AssessmentLogEntriesFiltering {
+  key: AssessmentLogEntriesFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum AssessmentLogEntriesFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Event Start"
+  event_start
+  "Event End"
+  event_end
+  "Name"
+  name
+}
+# Pagination Types
+type AssessmentLogEntryConnection {
+  pageInfo: PageInfo!
+  edges: [AssessmentLogEntryEdge]
+}
+type AssessmentLogEntryEdge {
+  cursor: String!
+  node: AssessmentLogEntry!
+}
 
 ## Risk Log Entry
 #
-  "Defines identifying information about a log entry of all risk-related tasks taken."
-  type RiskLogEntry implements BasicObject & LifecycleObject & OscalObject & LogEntry {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Entry
-    "Identifies the type of remediation tracking entry."
-    entry_type: [EntryType!]!
-    "Identifies the name for the risk log entry."
-    name: String!
-    "Identifies a human-readable description of of what was done regarding the risk."
-    description: String!
-    "Identifies the start date and time of the event."
-    event_start: Timestamp!
-    "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
-    event_end: Timestamp
-    "Used to indicate who created a log entry in what role."
-    logged_by: [LogEntryAuthor]
-    "Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries."
-    status_change: RiskStatus
-    "Identifies an individual risk response that this log entry is for."
-    related_responses: [RiskResponse]
-  }
-  "Defines identifying information about a log entry of all risk-related tasks taken."
-  input RiskLogEntryAddInput  {
-    "Identifies a reference to the Risk for which this is a log entry so that it can be attached."
-    risk_id: ID!
-    # Entry
-    "Identifies the type of remediation tracking entry."
-    entry_type: [EntryType!]!
-    "Identifies the name for the risk log entry."
-    name: String!
-    "Identifies a human-readable description of of what was done regarding the risk."
-    description: String!
-    "Identifies the start date and time of the event."
-    event_start: Timestamp!
-    "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
-    event_end: Timestamp
-    "Used to indicate the party that created a log entry in what role."
-    logged_by: [LogEntryAuthorAddInput]
-    "Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries."
-    status_change: RiskStatus
-    "Identifies a reference individual risk response that this log entry is for."
-    related_responses: [ID]
-  }
-  # Ordering Type
-  enum RiskLogEntriesOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Event Start"
-    event_start
-    "Event End"
-    event_end
-    "Entry Type"
-    entry_type
-    "Name"
-    name
-    "Status Change"
-    status_change
-  }
-  # Filtering Types
-  input RiskLogEntriesFiltering {
-    key: RiskLogEntriesFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a log entry of all risk-related tasks taken."
+type RiskLogEntry implements BasicObject & LifecycleObject & OscalObject & LogEntry {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum RiskLogEntriesFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Event Start"
-    event_start
-    "Event End"
-    event_end
-    "Entry Type"
-    entry_type
-    "Name"
-    name
-    "Status Change"
-    status_change
-  }
-  # Pagination Types
-  type RiskLogEntryConnection {
-    pageInfo: PageInfo!
-    edges: [RiskLogEntryEdge]
-  }
-  type RiskLogEntryEdge {
-    cursor: String!
-    node: RiskLogEntry!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Entry
+  "Identifies the type of remediation tracking entry."
+  entry_type: [EntryType!]!
+  "Identifies the name for the risk log entry."
+  name: String!
+  "Identifies a human-readable description of of what was done regarding the risk."
+  description: String!
+  "Identifies the start date and time of the event."
+  event_start: Timestamp!
+  "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
+  event_end: Timestamp
+  "Used to indicate who created a log entry in what role."
+  logged_by: [LogEntryAuthor]
+  "Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries."
+  status_change: RiskStatus
+  "Identifies an individual risk response that this log entry is for."
+  related_responses: [RiskResponse]
+}
+"Defines identifying information about a log entry of all risk-related tasks taken."
+input RiskLogEntryAddInput {
+  "Identifies a reference to the Risk for which this is a log entry so that it can be attached."
+  risk_id: ID!
+  # Entry
+  "Identifies the type of remediation tracking entry."
+  entry_type: [EntryType!]!
+  "Identifies the name for the risk log entry."
+  name: String!
+  "Identifies a human-readable description of of what was done regarding the risk."
+  description: String!
+  "Identifies the start date and time of the event."
+  event_start: Timestamp!
+  "Identifies the end date and time of the event. If the event is a point in time, the start and end will be the same date and time."
+  event_end: Timestamp
+  "Used to indicate the party that created a log entry in what role."
+  logged_by: [LogEntryAuthorAddInput]
+  "Identifies a change in risk status made resulting from the task described by this risk log entry. This allows the risk's status history to be captured as a sequence of risk log entries."
+  status_change: RiskStatus
+  "Identifies a reference individual risk response that this log entry is for."
+  related_responses: [ID]
+}
+# Ordering Type
+enum RiskLogEntriesOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Event Start"
+  event_start
+  "Event End"
+  event_end
+  "Entry Type"
+  entry_type
+  "Name"
+  name
+  "Status Change"
+  status_change
+  "Marking"
+  marking
+}
+# Filtering Types
+input RiskLogEntriesFiltering {
+  key: RiskLogEntriesFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum RiskLogEntriesFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Event Start"
+  event_start
+  "Event End"
+  event_end
+  "Entry Type"
+  entry_type
+  "Name"
+  name
+  "Status Change"
+  status_change
+}
+# Pagination Types
+type RiskLogEntryConnection {
+  pageInfo: PageInfo!
+  edges: [RiskLogEntryEdge]
+}
+type RiskLogEntryEdge {
+  cursor: String!
+  node: RiskLogEntry!
+}
 
 ## Mitigating Factor
 #
-  "Defines identifying information about a mitigation factor."
-  type MitigatingFactor implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Mitigating Factor
-    # "Identifies a reference to an implementation statement in the SSP."
-    # implementation: ImplementationStatement
-    "Identifies a human-readable description of this mitigating factor."
-    description: String
-    "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
-    subjects: [Subject]
-  }
-  input MitigatingFactorAddInput {
-    "Identifies a reference to the Risk for which this is a mitigating factor so that it can be attached."
-    risk_id: ID!
-    # "Identifies a reference to an implementation statement in the SSP."
-    # implementation: ImplementationStatement
-    "Identifies a human-readable description of this mitigating factor."
-    description: String
-    "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
-    subjects: [SubjectAddInput]
-  }
-  # Ordering Type
-  enum MitigatingFactorOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Filtering Types
-  input MitigatingFactorFiltering {
-    key: MitigatingFactorFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a mitigation factor."
+type MitigatingFactor implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum MitigatingFactorFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Pagination Types
-  type MitigatingFactorConnection {
-    pageInfo: PageInfo!
-    edges: [MitigatingFactorEdge]
-  }
-  type MitigatingFactorEdge {
-    cursor: String!
-    node: MitigatingFactor!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Mitigating Factor
+  # "Identifies a reference to an implementation statement in the SSP."
+  # implementation: ImplementationStatement
+  "Identifies a human-readable description of this mitigating factor."
+  description: String
+  "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
+  subjects: [Subject]
+}
+input MitigatingFactorAddInput {
+  "Identifies a reference to the Risk for which this is a mitigating factor so that it can be attached."
+  risk_id: ID!
+  # "Identifies a reference to an implementation statement in the SSP."
+  # implementation: ImplementationStatement
+  "Identifies a human-readable description of this mitigating factor."
+  description: String
+  "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
+  subjects: [SubjectAddInput]
+}
+# Ordering Type
+enum MitigatingFactorOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input MitigatingFactorFiltering {
+  key: MitigatingFactorFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum MitigatingFactorFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+}
+# Pagination Types
+type MitigatingFactorConnection {
+  pageInfo: PageInfo!
+  edges: [MitigatingFactorEdge]
+}
+type MitigatingFactorEdge {
+  cursor: String!
+  node: MitigatingFactor!
+}
 
 ## Observation
 #
-  "Defines identifying information about an observation."
-  type Observation implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Observation
-    "Identifies the name for the observation."
-    name: String!
-    "Identifies a human-readable description of the assessment observation."
-    description: String
-    "Identifies how the observation was made."
-    methods: [MethodTypes!]!
-    "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
-    observation_types: [ObservationType]
-    "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
-    origins: [Origin]
-    "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
-    subjects: [Subject]
-    "Identifies relevant evidence collected as part of this observation."
-    relevant_evidence: [Evidence]
-    "Identifies a Date/time stamp identifying when the finding information was collected."
-    collected: Timestamp
-    "Identifies Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios."
-    expires: Timestamp
-  }
-  input ObservationAddInput {
-    "Identifies the name for the observation."
-    name: String!
-    "Identifies a human-readable description of the assessment observation."
-    description: String!
-    "Identifies how the observation was made."
-    methods: [MethodTypes!]!
-    "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
-    observation_types: [ObservationType]
-    "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
-    origins: [OriginAddInput]
-    "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
-    subjects: [SubjectAddInput]
-    "Identifies relevant evidence collected as part of this observation."
-    relevant_evidence: [EvidenceAddInput]
-    "Identifies a Date/time stamp identifying when the finding information was collected."
-    collected: Timestamp!
-    "Identifies Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios."
-    expires: Timestamp
-  }
-  # Ordering Type
-  enum ObservationsOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Observation Method"
-    methods
-    "Obsevation Type"
-    observation_types
-    "Collection Date"
-    collected
-    "Expiration Date"
-    expires
-    "Source"
-    origin_name
-  }
-  # Filtering Types
-  input ObservationsFiltering {
-    key: ObservationsFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about an observation."
+type Observation implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum ObservationsFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Observation Method"
-    method
-    "Observation Type"
-    observation_type
-    "Collection Date"
-    collected
-    "Expiration Date"
-    expires
-    "Source"
-    origin_name
-  }
-  # Pagination Types
-  type ObservationConnection {
-    pageInfo: PageInfo!
-    edges: [ObservationEdge]
-  }
-  type ObservationEdge {
-    cursor: String!
-    node: Observation!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Observation
+  "Identifies the name for the observation."
+  name: String!
+  "Identifies a human-readable description of the assessment observation."
+  description: String
+  "Identifies how the observation was made."
+  methods: [MethodTypes!]!
+  "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
+  observation_types: [ObservationType]
+  "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
+  origins: [Origin]
+  "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
+  subjects: [Subject]
+  "Identifies relevant evidence collected as part of this observation."
+  relevant_evidence: [Evidence]
+  "Identifies a Date/time stamp identifying when the finding information was collected."
+  collected: Timestamp
+  "Identifies Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios."
+  expires: Timestamp
+}
+input ObservationAddInput {
+  "Identifies the name for the observation."
+  name: String!
+  "Identifies a human-readable description of the assessment observation."
+  description: String!
+  "Identifies how the observation was made."
+  methods: [MethodTypes!]!
+  "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
+  observation_types: [ObservationType]
+  "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
+  origins: [OriginAddInput]
+  "Identifies a reference to one or more subjects of the observations.  The subject indicates what was observed, who was interviewed, or what was tested or inspected."
+  subjects: [SubjectAddInput]
+  "Identifies relevant evidence collected as part of this observation."
+  relevant_evidence: [EvidenceAddInput]
+  "Identifies a Date/time stamp identifying when the finding information was collected."
+  collected: Timestamp!
+  "Identifies Date/time identifying when the finding information is out-of-date and no longer valid. Typically used with continuous assessment scenarios."
+  expires: Timestamp
+}
+# Ordering Type
+enum ObservationsOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Observation Method"
+  methods
+  "Obsevation Type"
+  observation_types
+  "Collection Date"
+  collected
+  "Expiration Date"
+  expires
+  "Source"
+  origin_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input ObservationsFiltering {
+  key: ObservationsFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum ObservationsFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Observation Method"
+  method
+  "Observation Type"
+  observation_type
+  "Collection Date"
+  collected
+  "Expiration Date"
+  expires
+  "Source"
+  origin_name
+}
+# Pagination Types
+type ObservationConnection {
+  pageInfo: PageInfo!
+  edges: [ObservationEdge]
+}
+type ObservationEdge {
+  cursor: String!
+  node: Observation!
+}
 
 ## Origin
 #
-  "Defines identifying information about the source of the finding, such as a tool, interviewed person, or activity."
-  type Origin {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies one or more actors that produces an observation, a finding, or a risk. One or more actor type can be used to specify a person that is using a tool."
-    origin_actors: [Actor!]!
-    "Identifies one or more task for which the containing object is a consequence of."
-    related_tasks: [OscalTask]
-  }
-  input OriginAddInput {
-    origin_actors: [ActorAddInput!]!
-    related_tasks: [ID]
-  }
-  # Filtering Types
-  input OriginFiltering {
-    key: OriginFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum OriginOrdering {
-    "Name"
-    actor_name
-  }
-  enum OriginFilter {
-    "Name"
-    actor_name
-  }
-  # Pagination Types
-  type OriginConnection {
-    pageInfo: PageInfo!
-    edges: [OriginEdge]
-  }
-  type OriginEdge {
-    cursor: String!
-    node: Origin!
-  }
+"Defines identifying information about the source of the finding, such as a tool, interviewed person, or activity."
+type Origin {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies one or more actors that produces an observation, a finding, or a risk. One or more actor type can be used to specify a person that is using a tool."
+  origin_actors: [Actor!]!
+  "Identifies one or more task for which the containing object is a consequence of."
+  related_tasks: [OscalTask]
+}
+input OriginAddInput {
+  origin_actors: [ActorAddInput!]!
+  related_tasks: [ID]
+}
+# Filtering Types
+input OriginFiltering {
+  key: OriginFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum OriginOrdering {
+  "Name"
+  actor_name
+}
+enum OriginFilter {
+  "Name"
+  actor_name
+}
+# Pagination Types
+type OriginConnection {
+  pageInfo: PageInfo!
+  edges: [OriginEdge]
+}
+type OriginEdge {
+  cursor: String!
+  node: Origin!
+}
 
 ## Task
 "Defines an abstract interface for identifying information about a scheduled event or milestone, which may be associated with a series of assessment actions."
@@ -1569,7 +1633,7 @@ type OscalTask implements BasicObject & LifecycleObject & OscalObject {
     orderMode: OrderingMode
     filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-    search: String 
+    search: String
   ): OscalRelationshipConnection
   # Task
   "Identifies the type of task."
@@ -1627,6 +1691,8 @@ enum OscalTaskOrdering {
   task_type
   "Name"
   name
+  "Marking"
+  marking
 }
 # Filtering Types
 input OscalTaskFiltering {
@@ -1659,763 +1725,780 @@ type OscalTaskEdge {
 
 ## RequiredAsset
 #
-  "Defines identifying information about an asset required to achieve remediation."
-  type RequiredAsset implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Required Asset
-    "Identifies the name of the required asset."
-    name: String!
-    "Identifies a human-readable description of the required asset."
-    description: String
-    "Identifies a reference to one or more subjects, in the form of a party or tool required to achieve the remediation."
-    subjects: [Subject]
-  }
-  input RequiredAssetAddInput {
-    "Identifies a reference to the Risk Response to which the required asset is to be attached."
-    remediation_id: ID
-    # Required Asset
-    "Identifies the name of the required asset."
-    name: String!
-    "Identifies a human-readable description of the required asset."
-    description: String!
-    "Identifies a reference to one or more subjects, in the form of a party or tool required to achieve the remediation."
-    subjects: [SubjectAddInput]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [ID]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [ID]
-  }
-  # Ordering Type
-  enum RequiredAssetOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Filtering Types
-  input RequiredAssetFiltering {
-    key: RequiredAssetFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about an asset required to achieve remediation."
+type RequiredAsset implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum RequiredAssetFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Pagination Types
-  type RequiredAssetConnection {
-    pageInfo: PageInfo!
-    edges: [RequiredAssetEdge]
-  }
-  type RequiredAssetEdge {
-    cursor: String!
-    node: RequiredAsset!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Required Asset
+  "Identifies the name of the required asset."
+  name: String!
+  "Identifies a human-readable description of the required asset."
+  description: String
+  "Identifies a reference to one or more subjects, in the form of a party or tool required to achieve the remediation."
+  subjects: [Subject]
+}
+input RequiredAssetAddInput {
+  "Identifies a reference to the Risk Response to which the required asset is to be attached."
+  remediation_id: ID
+  # Required Asset
+  "Identifies the name of the required asset."
+  name: String!
+  "Identifies a human-readable description of the required asset."
+  description: String!
+  "Identifies a reference to one or more subjects, in the form of a party or tool required to achieve the remediation."
+  subjects: [SubjectAddInput]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [ID]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [ID]
+}
+# Ordering Type
+enum RequiredAssetOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Marking"
+  marking
+}
+# Filtering Types
+input RequiredAssetFiltering {
+  key: RequiredAssetFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum RequiredAssetFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+}
+# Pagination Types
+type RequiredAssetConnection {
+  pageInfo: PageInfo!
+  edges: [RequiredAssetEdge]
+}
+type RequiredAssetEdge {
+  cursor: String!
+  node: RequiredAsset!
+}
 
-
-  "Defines identifying information about a Risk"
-  type Risk implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Risk
-    "Identifies the name for the risk."
-    name: String!
-    "Identifies a human-readable summary of the identified risk, to include a statement of how the risk impacts the system."
-    description: String
-    "Identifies a summary of impact for how the risk affects the system."
-    statement: String
-    "Identifies the status of the associated risk."
-    risk_status: RiskStatus!
-    "Identifies the level of risk"
-    risk_level: RiskLevel
-    "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
-    origins: [Origin]
-    "Identifies a reference to one or more externally-defined threats."
-    threats: [ThreatReference]
-    "Identifies a collection of descriptive data about the containing object from a specific origin."
-    characterizations: [Characterization]
-    "Identifies one or more existing mitigating factors that may affect the overall determination of the risk, with an optional link to an implementation statement in the SSP."
-    mitigating_factors: [MitigatingFactor]
-    "Identifies the date/time by which the risk must be resolved."
-    deadline: Timestamp
-    "Identifies either recommended or an actual plan for addressing the risk."
-    remediations: [RiskResponse]
-    "log of all risk-related tasks taken."
-    risk_log(first: Int, offset: Int): RiskLogEntryConnection
-    "Relates the finding to a set of referenced observations that were used to determine the risk.  This would be the Component in which the risk exists and the InventoryItem(s) in which theComponent is installed"
-    related_observations(first: Int, offset: Int): ObservationConnection
-    "Identifies that the risk has been confirmed to be a false positive."
-    false_positive: RiskAssertionState
-    "Identifies that the risk cannot be remediated without impact to the system and must be accepted."
-    accepted: RiskAssertionState
-    "Identifies that mitigating factors were identified or implemented, reducing the likelihood or impact of the risk."
-    risk_adjusted: RiskAssertionState
-    "Identifies Assessor's recommended risk priority. Lower numbers are higher priority. One (1) is highest priority."
-    priority: PositiveInt
-    "Identifies that a vendor resolution is pending, but not yet available."
-    vendor_dependency: RiskAssertionState
-    "Identifies a control impacted by this risk."
-    impacted_control_id: String
-    # Risk Response
-    "Identifies the type of response to the risk"
-    response_type: ResponseType
-    "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
-    lifecycle: RiskLifeCyclePhase
-    # POAM ID
-    "Identifies the POAM ID associated with the related POAM Item referencing this Risk"
-    poam_id: String
-    "Indicate the number of occurrences of the risk based on observations associated with the risk"
-    occurrences: Int
-  }
-  input RiskAddInput {
-    "Identifies the name for the risk."
-    name: String!
-    "Identifies a human-readable summary of the identified risk, to include a statement of how the risk impacts the system."
-    description: String!
-    "Identifies a summary of impact for how the risk affects the system."
-    statement: String!
-    "Identifies the status of the associated risk."
-    risk_status: RiskStatus!
-    "Identifies the date/time by which the risk must be resolved."
-    deadline: Timestamp
-    "Identifies that the risk has been confirmed to be a false positive."
-    false_positive: RiskAssertionState
-    "Identifies that the risk cannot be remediated without impact to the system and must be accepted."
-    accepted: RiskAssertionState
-    "Identifies that mitigating factors were identified or implemented, reducing the likelihood or impact of the risk."
-    risk_adjusted: RiskAssertionState
-    "Identifies Assessor's recommended risk priority. Lower numbers are higher priority. One (1) is highest priority."
-    priority: PositiveInt
-    "Identifies that a vendor resolution is pending, but not yet available."
-    vendor_dependency: RiskAssertionState
-    "Identifies a control impacted by this risk."
-    impacted_control_id: String
-  }
-  # Risk Ordering
-  enum RisksOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "POAM ID"
-    poam_id
-    "Name"
-    name
-    "Risk Level"
-    risk_level
-    "Risk Status"
-    risk_status
-    "Response Type"
-    response_type
-    "Lifecycle"
-    lifecycle
-    "Occurrences"
-    occurrences
-    "Deadline"
-    deadline
-  }
-  # Filtering Types
-  input RisksFiltering {
-    key: RisksFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a Risk"
+type Risk implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum RisksFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Risk Level"
-    risk_level
-    "Risk Status"
-    risk_status
-    "Deadline"
-    deadline
-  }
-  # Pagination Types
-  type RiskConnection {
-    pageInfo: PageInfo!
-    edges: [RiskEdge]
-  }
-  type RiskEdge {
-    cursor: String!
-    node: Risk!
-  }
-
+    search: String
+  ): OscalRelationshipConnection
+  # Risk
+  "Identifies the name for the risk."
+  name: String!
+  "Identifies a human-readable summary of the identified risk, to include a statement of how the risk impacts the system."
+  description: String
+  "Identifies a summary of impact for how the risk affects the system."
+  statement: String
+  "Identifies the status of the associated risk."
+  risk_status: RiskStatus!
+  "Identifies the level of risk"
+  risk_level: RiskLevel
+  "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
+  origins: [Origin]
+  "Identifies a reference to one or more externally-defined threats."
+  threats: [ThreatReference]
+  "Identifies a collection of descriptive data about the containing object from a specific origin."
+  characterizations: [Characterization]
+  "Identifies one or more existing mitigating factors that may affect the overall determination of the risk, with an optional link to an implementation statement in the SSP."
+  mitigating_factors: [MitigatingFactor]
+  "Identifies the date/time by which the risk must be resolved."
+  deadline: Timestamp
+  "Identifies either recommended or an actual plan for addressing the risk."
+  remediations: [RiskResponse]
+  "log of all risk-related tasks taken."
+  risk_log(first: Int, offset: Int): RiskLogEntryConnection
+  "Relates the finding to a set of referenced observations that were used to determine the risk.  This would be the Component in which the risk exists and the InventoryItem(s) in which theComponent is installed"
+  related_observations(first: Int, offset: Int): ObservationConnection
+  "Identifies that the risk has been confirmed to be a false positive."
+  false_positive: RiskAssertionState
+  "Identifies that the risk cannot be remediated without impact to the system and must be accepted."
+  accepted: RiskAssertionState
+  "Identifies that mitigating factors were identified or implemented, reducing the likelihood or impact of the risk."
+  risk_adjusted: RiskAssertionState
+  "Identifies Assessor's recommended risk priority. Lower numbers are higher priority. One (1) is highest priority."
+  priority: PositiveInt
+  "Identifies that a vendor resolution is pending, but not yet available."
+  vendor_dependency: RiskAssertionState
+  "Identifies a control impacted by this risk."
+  impacted_control_id: String
+  # Risk Response
+  "Identifies the type of response to the risk"
+  response_type: ResponseType
+  "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
+  lifecycle: RiskLifeCyclePhase
+  # POAM ID
+  "Identifies the POAM ID associated with the related POAM Item referencing this Risk"
+  poam_id: String
+  "Indicate the number of occurrences of the risk based on observations associated with the risk"
+  occurrences: Int
+}
+input RiskAddInput {
+  "Identifies the name for the risk."
+  name: String!
+  "Identifies a human-readable summary of the identified risk, to include a statement of how the risk impacts the system."
+  description: String!
+  "Identifies a summary of impact for how the risk affects the system."
+  statement: String!
+  "Identifies the status of the associated risk."
+  risk_status: RiskStatus!
+  "Identifies the date/time by which the risk must be resolved."
+  deadline: Timestamp
+  "Identifies that the risk has been confirmed to be a false positive."
+  false_positive: RiskAssertionState
+  "Identifies that the risk cannot be remediated without impact to the system and must be accepted."
+  accepted: RiskAssertionState
+  "Identifies that mitigating factors were identified or implemented, reducing the likelihood or impact of the risk."
+  risk_adjusted: RiskAssertionState
+  "Identifies Assessor's recommended risk priority. Lower numbers are higher priority. One (1) is highest priority."
+  priority: PositiveInt
+  "Identifies that a vendor resolution is pending, but not yet available."
+  vendor_dependency: RiskAssertionState
+  "Identifies a control impacted by this risk."
+  impacted_control_id: String
+}
+# Risk Ordering
+enum RisksOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "POAM ID"
+  poam_id
+  "Name"
+  name
+  "Risk Level"
+  risk_level
+  "Risk Status"
+  risk_status
+  "Response Type"
+  response_type
+  "Lifecycle"
+  lifecycle
+  "Occurrences"
+  occurrences
+  "Deadline"
+  deadline
+  "Marking"
+  marking
+}
+# Filtering Types
+input RisksFiltering {
+  key: RisksFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum RisksFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Risk Level"
+  risk_level
+  "Risk Status"
+  risk_status
+  "Deadline"
+  deadline
+}
+# Pagination Types
+type RiskConnection {
+  pageInfo: PageInfo!
+  edges: [RiskEdge]
+}
+type RiskEdge {
+  cursor: String!
+  node: Risk!
+}
 
 ## Risk Response
 #
-  "Defines identifying information about a response to a risk."
-  type RiskResponse implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Risk Response
-    "Identifies the type of response to the risk"
-    response_type: ResponseType!
-    "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
-    lifecycle: RiskLifeCyclePhase!
-    "Identifies the name for the response activity."
-    name: String!
-    "Identifies a human-readable description of the response plan."
-    description: String
-    "Identifies one or more sources of individuals and/or tools that generated this recommended or planned response."
-    origins: [Origin]
-    "Identifies an asset required to achieve remediation."
-    required_assets: [RequiredAsset]
-    "Identifies one or more scheduled events or milestones, which may be associated with a series of assessment actions."
-    tasks: [OscalTask]
-  }
-  input RiskResponseAddInput {
-    "Identifies a reference to the Risk for which this is a remediation action so that it can be attached."
-    risk_id: ID!
-    # Risk Response
-    "Identifies the type of response to the risk"
-    response_type: ResponseType!
-    "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
-    lifecycle: RiskLifeCyclePhase!
-    "Identifies the name for the response activity."
-    name: String!
-    "Identifies a human-readable description of the response plan."
-    description: String!
-    "Identifies one or more sources of individuals and/or tools that generated this recommended or planned response."
-    origins: [OriginAddInput!]!
-    "Identifies an asset required to achieve remediation."
-    required_assets: [ID]
-    "Identifies one or more scheduled events or milestones, which may be associated with a series of assessment actions."
-    tasks: [ID]
-  }
-  # Ordering Types
-  enum RiskResponsesOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Response Type"
-    response_type
-    "Response Lifecycle"
-    lifecycle
-    "Name"
-    name
-    "Source"
-    origin_name
-  }
-  # Filtering Types
-  input RiskResponsesFiltering {
-    key: RiskResponseFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a response to a risk."
+type RiskResponse implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum RiskResponseFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Response Type"
-    response_type
-    "Response Lifecycle"
-    lifecycle
-    "Name"
-    name
-    "Source"
-    origin_name
-  }
-  # Pagination Types
-  type RiskResponseConnection {
-    pageInfo: PageInfo!
-    edges: [RiskResponseEdge]
-  }
-  type RiskResponseEdge {
-    cursor: String!
-    node: RiskResponse!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Risk Response
+  "Identifies the type of response to the risk"
+  response_type: ResponseType!
+  "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
+  lifecycle: RiskLifeCyclePhase!
+  "Identifies the name for the response activity."
+  name: String!
+  "Identifies a human-readable description of the response plan."
+  description: String
+  "Identifies one or more sources of individuals and/or tools that generated this recommended or planned response."
+  origins: [Origin]
+  "Identifies an asset required to achieve remediation."
+  required_assets: [RequiredAsset]
+  "Identifies one or more scheduled events or milestones, which may be associated with a series of assessment actions."
+  tasks: [OscalTask]
+}
+input RiskResponseAddInput {
+  "Identifies a reference to the Risk for which this is a remediation action so that it can be attached."
+  risk_id: ID!
+  # Risk Response
+  "Identifies the type of response to the risk"
+  response_type: ResponseType!
+  "Identifies whether this is a recommendation, such as from an assessor or tool, or an actual plan accepted by the system owner."
+  lifecycle: RiskLifeCyclePhase!
+  "Identifies the name for the response activity."
+  name: String!
+  "Identifies a human-readable description of the response plan."
+  description: String!
+  "Identifies one or more sources of individuals and/or tools that generated this recommended or planned response."
+  origins: [OriginAddInput!]!
+  "Identifies an asset required to achieve remediation."
+  required_assets: [ID]
+  "Identifies one or more scheduled events or milestones, which may be associated with a series of assessment actions."
+  tasks: [ID]
+}
+# Ordering Types
+enum RiskResponsesOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Response Type"
+  response_type
+  "Response Lifecycle"
+  lifecycle
+  "Name"
+  name
+  "Source"
+  origin_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input RiskResponsesFiltering {
+  key: RiskResponseFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum RiskResponseFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Response Type"
+  response_type
+  "Response Lifecycle"
+  lifecycle
+  "Name"
+  name
+  "Source"
+  origin_name
+}
+# Pagination Types
+type RiskResponseConnection {
+  pageInfo: PageInfo!
+  edges: [RiskResponseEdge]
+}
+type RiskResponseEdge {
+  cursor: String!
+  node: RiskResponse!
+}
 
 ## Subject
 #
-  "Defines the identifying information about a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else."
-  type Subject {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies the name for the referenced subject."
-    name: String
-    "Identifies the optional context which the subject represents: 'target' or 'secondary-target'"
-    subject_context: SubjectContext
-    "Indicates the type of subject"
-    subject_type: SubjectType!
-    "Identifies a reference to a component, inventory-item, location, party, user, or resource."
-    subject_ref: SubjectTarget!
-  }
-  input SubjectAddInput {
-    "Identifies the name for the referenced subject."
-    name: String
-    "Identifies the optional context which the subject represents: 'target' or 'secondary-target'"
-    subject_context: SubjectContext
-    "Indicates the type of subject"
-    subject_type: SubjectType!
-    "Identifies a reference to a component, inventory-item, location, party, user, or resource."
-    subject_ref: ID!
-  }
-  # Ordering Types
-  enum SubjectOrdering {
-    "Subject Context"
-    subject_context
-    "Subject Type"
-    subject_type
-    "Name"
-    name
-  }
-  # Filtering Types
-  input SubjectFiltering {
-    key: SubjectFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum SubjectFilter {
-    "Subject Context"
-    subject_context
-    "Subject Type"
-    subject_type
-    "Name"
-    name
-  }
-  # Pagination Types
-  type SubjectConnection {
-    pageInfo: PageInfo!
-    edges: [SubjectEdge]
-  }
-  type SubjectEdge {
-    cursor: String!
-    node: Subject!
-  }
-  # Subject Context
-  enum SubjectContext {
-    "Indicates the Subject is the primary target."
-    target
-    "Indicates the Subject is a secondary target."
-    secondary_target
-  }
+"Defines the identifying information about a resource. Use type to indicate whether the identified resource is a component, inventory item, location, user, or something else."
+type Subject {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies the name for the referenced subject."
+  name: String
+  "Identifies the optional context which the subject represents: 'target' or 'secondary-target'"
+  subject_context: SubjectContext
+  "Indicates the type of subject"
+  subject_type: SubjectType!
+  "Identifies a reference to a component, inventory-item, location, party, user, or resource."
+  subject_ref: SubjectTarget!
+}
+input SubjectAddInput {
+  "Identifies the name for the referenced subject."
+  name: String
+  "Identifies the optional context which the subject represents: 'target' or 'secondary-target'"
+  subject_context: SubjectContext
+  "Indicates the type of subject"
+  subject_type: SubjectType!
+  "Identifies a reference to a component, inventory-item, location, party, user, or resource."
+  subject_ref: ID!
+}
+# Ordering Types
+enum SubjectOrdering {
+  "Subject Context"
+  subject_context
+  "Subject Type"
+  subject_type
+  "Name"
+  name
+}
+# Filtering Types
+input SubjectFiltering {
+  key: SubjectFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum SubjectFilter {
+  "Subject Context"
+  subject_context
+  "Subject Type"
+  subject_type
+  "Name"
+  name
+}
+# Pagination Types
+type SubjectConnection {
+  pageInfo: PageInfo!
+  edges: [SubjectEdge]
+}
+type SubjectEdge {
+  cursor: String!
+  node: Subject!
+}
+# Subject Context
+enum SubjectContext {
+  "Indicates the Subject is the primary target."
+  target
+  "Indicates the Subject is a secondary target."
+  secondary_target
+}
 
 ## Threat Reference
 #
-  "Defines identifying information about a reference to a threat."
-  type ThreatReference {
-    "Identifies the source of the threat information."
-    source_system: URL!
-    "Identifies an optional location for the threat data, from which this ID originates."
-    href: URL
-    "Identifies the specific identifier associated with the threat."
-    threat_identifier: URL
-  }
-
+"Defines identifying information about a reference to a threat."
+type ThreatReference {
+  "Identifies the source of the threat information."
+  source_system: URL!
+  "Identifies an optional location for the threat data, from which this ID originates."
+  href: URL
+  "Identifies the specific identifier associated with the threat."
+  threat_identifier: URL
+}
 
 ## Unions
 #
-  # union StatementOrObjects = ControlStatement | ControlObjective
-  union ActorTarget = OscalParty | AssessmentPlatform | Component
-  union PartyOrComponent = OscalParty | Component | HardwareComponent | NetworkComponent | ServiceComponent | SoftwareComponent | SystemComponent
-  union SubjectTarget = Component | InventoryItem | OscalLocation | OscalParty | OscalUser | OscalResource | SoftwareAsset | HardwareAsset
+# union StatementOrObjects = ControlStatement | ControlObjective
+union ActorTarget = OscalParty | AssessmentPlatform | Component
+# union PartyOrComponent =
+#     OscalParty
+#   | Component
+  # | HardwareComponent
+  # | NetworkComponent
+  # | ServiceComponent
+  # | SoftwareComponent
+  # | SystemComponent
+union SubjectTarget =
+    Component
+  | InventoryItem
+  | OscalLocation
+  | OscalParty
+  | OscalUser
+  | OscalResource
+  | SoftwareAsset
+  | HardwareAsset
 
 ## Enumerations
 #
-  "Defines the types of actors"
-  enum ActorType {
-    "A reference to a tool component defined with the assessment assets."
-    tool
-    "A reference to an assessment-platform defined with the assessment assets."
-    assessment_platform
-    "A reference to an assessment-platform defined with the assessment assets."
-    party
-  }
+"Defines the types of actors"
+enum ActorType {
+  "A reference to a tool component defined with the assessment assets."
+  tool
+  "A reference to an assessment-platform defined with the assessment assets."
+  assessment_platform
+  "A reference to an assessment-platform defined with the assessment assets."
+  party
+}
 
-  "Defines the type of remediation tracking entry. Can be multi-valued."
-  enum EntryType {
-    "Contacted vendor to determine the status of a pending fix to a known vulnerability."
-    vendor_check_in
-    "Information related to the current state of response to this risk."
-    status_update
-    "A significant step in the response plan has been achieved."
-    milestone_complete
-    "An activity was completed that reduces the likelihood or impact of this risk."
-    mitigation
-    "An activity was completed that eliminates the likelihood or impact of this risk."
-    remediated
-    "The risk is no longer applicable to the system."
-    closed
-    "A deviation request was made to the authorizing official."
-    dr_submission
-    "A previously submitted deviation request has been modified."
-    dr_updated
-    "The authorizing official approved the deviation."
-    dr_approved
-    "The authorizing official rejected the deviation."
-    dr_rejected
-  }
+"Defines the type of remediation tracking entry. Can be multi-valued."
+enum EntryType {
+  "Contacted vendor to determine the status of a pending fix to a known vulnerability."
+  vendor_check_in
+  "Information related to the current state of response to this risk."
+  status_update
+  "A significant step in the response plan has been achieved."
+  milestone_complete
+  "An activity was completed that reduces the likelihood or impact of this risk."
+  mitigation
+  "An activity was completed that eliminates the likelihood or impact of this risk."
+  remediated
+  "The risk is no longer applicable to the system."
+  closed
+  "A deviation request was made to the authorizing official."
+  dr_submission
+  "A previously submitted deviation request has been modified."
+  dr_updated
+  "The authorizing official approved the deviation."
+  dr_approved
+  "The authorizing official rejected the deviation."
+  dr_rejected
+}
 
-  "Defines the maturity levels of an exploit."
-  enum ExploitMaturity {
-    "No exploit code is available, or an exploit is theoretical."
-    unproven
-    "Proof-of-concept exploit code is available, or an attack demonstration is not practical for most systems."
-    proof_of_concept
-    "Functional exploit code is available. The code works in most situations where the vulnerability exists."
-    functional
-    "Functional autonomous code exists, or no exploit is required (manual trigger) and details are widely available."
-    high
-    "Insufficient information to definitely know."
-    not_defined
-  }
+"Defines the maturity levels of an exploit."
+enum ExploitMaturity {
+  "No exploit code is available, or an exploit is theoretical."
+  unproven
+  "Proof-of-concept exploit code is available, or an attack demonstration is not practical for most systems."
+  proof_of_concept
+  "Functional exploit code is available. The code works in most situations where the vulnerability exists."
+  functional
+  "Functional autonomous code exists, or no exploit is required (manual trigger) and details are widely available."
+  high
+  "Insufficient information to definitely know."
+  not_defined
+}
 
-  "Defines the states of a Facet identification"
-  enum RiskState {
-    "As first identified."
-    initial
-    "Indicates that residual risk remains after some adjustments have been made."
-    adjusted
-  }
+"Defines the states of a Facet identification"
+enum RiskState {
+  "As first identified."
+  initial
+  "Indicates that residual risk remains after some adjustments have been made."
+  adjusted
+}
 
-  "Identifies the implementation status of the control or control objective."
-  enum ImplementationStatus {
-    "The control is fully implemented."
-    implemented
-    "The control is partially implemented."
-    partial
-    "There is a plan for implementing the control as explained in the remarks."
-    planned
-    "There is a plan for implementing the control as explained in the remarks."
-    alternative
-    "This control does not apply to this system as justified in the remarks."
-    not_applicable
-  }
+"Identifies the implementation status of the control or control objective."
+enum ImplementationStatus {
+  "The control is fully implemented."
+  implemented
+  "The control is partially implemented."
+  partial
+  "There is a plan for implementing the control as explained in the remarks."
+  planned
+  "There is a plan for implementing the control as explained in the remarks."
+  alternative
+  "This control does not apply to this system as justified in the remarks."
+  not_applicable
+}
 
-  "Defined the types of methods for making an observation."
-  enum MethodTypes {
-    "An inspection was performed."
-    EXAMINE
-    "An interview was performed."
-    INTERVIEW
-    "A manual or automated test was performed."
-    TEST
-  }
+"Defined the types of methods for making an observation."
+enum MethodTypes {
+  "An inspection was performed."
+  EXAMINE
+  "An interview was performed."
+  INTERVIEW
+  "A manual or automated test was performed."
+  TEST
+}
 
-  "Defines the reasons for the objective status"
-  enum ObjectiveStatusReason {
-    "The target system or system component satisfied all the conditions."
-    pass
-    "The target system or system component did not satisfy all the conditions."
-    fail
-    "The target system or system component did not satisfy all the conditions."
-    other
-  }
+"Defines the reasons for the objective status"
+enum ObjectiveStatusReason {
+  "The target system or system component satisfied all the conditions."
+  pass
+  "The target system or system component did not satisfy all the conditions."
+  fail
+  "The target system or system component did not satisfy all the conditions."
+  other
+}
 
-  "Defines the states of the objective status"
-  enum ObjectiveStatusState {
-    "The objective has been completely satisfied"
-    satisfied
-    "The objective has not been completely satisfied, but may be partially satisfied"
-    not_satisfied
-  }
+"Defines the states of the objective status"
+enum ObjectiveStatusState {
+  "The objective has been completely satisfied"
+  satisfied
+  "The objective has not been completely satisfied, but may be partially satisfied"
+  not_satisfied
+}
 
-  "Defines the types of observations"
-  enum ObservationType {
-    "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
-    ssp_statement_issue
-    "An observation about the status of a the associated control objective."
-    control_objective
-    "A mitigating factor was identified."
-    mitigation
-    "An assessment finding. Used for observations made by tools, penetration testing, and other means."
-    finding
-    "An observation from a past assessment, which was converted to OSCAL at a later date."
-    historic
-  }
+"Defines the types of observations"
+enum ObservationType {
+  "Identifies the nature of the observation. More than one may be used to further qualify and enable filtering."
+  ssp_statement_issue
+  "An observation about the status of a the associated control objective."
+  control_objective
+  "A mitigating factor was identified."
+  mitigation
+  "An assessment finding. Used for observations made by tools, penetration testing, and other means."
+  finding
+  "An observation from a past assessment, which was converted to OSCAL at a later date."
+  historic
+}
 
-  "Defines the types of risk responses"
-  enum ResponseType {
-    "The risk will be eliminated."
-    avoid
-    "The risk will be reduced."
-    mitigate
-    "The risk will be transferred to another organization or entity."
-    transfer
-    "The risk will continue to exist without further efforts to address it. (Sometimes referred to as 'Operationally required')"
-    accept
-    "The risk will be partially transferred to another organization or entity."
-    share
-    "Plans will be made to address the risk impact if the risk occurs. (This is a form of mitigation.)"
-    contingency
-    "No response, such as when the identified risk is found to be a false positive."
-    none
-  }
+"Defines the types of risk responses"
+enum ResponseType {
+  "The risk will be eliminated."
+  avoid
+  "The risk will be reduced."
+  mitigate
+  "The risk will be transferred to another organization or entity."
+  transfer
+  "The risk will continue to exist without further efforts to address it. (Sometimes referred to as 'Operationally required')"
+  accept
+  "The risk will be partially transferred to another organization or entity."
+  share
+  "Plans will be made to address the risk impact if the risk occurs. (This is a form of mitigation.)"
+  contingency
+  "No response, such as when the identified risk is found to be a false positive."
+  none
+}
 
-  "Defines the states of a risk assertion"
-  enum RiskAssertionState {
-    "Investigating assertion"
-    investigating
-    "Pending assertion decision"
-    pending
-    "Assertion approved"
-    approved
-    "Assertion withdrawn"
-    withdrawn
-  }
+"Defines the states of a risk assertion"
+enum RiskAssertionState {
+  "Investigating assertion"
+  investigating
+  "Pending assertion decision"
+  pending
+  "Assertion approved"
+  approved
+  "Assertion withdrawn"
+  withdrawn
+}
 
-  "Defines the set of phase of the risk lifecycle."
-  enum RiskLifeCyclePhase {
-    "Recommended Remediation"
-    recommendation
-    "The actions intended to resolve the risk."
-    planned
-    "This remediation activities were performed to address the risk."
-    completed
-  }
+"Defines the set of phase of the risk lifecycle."
+enum RiskLifeCyclePhase {
+  "Recommended Remediation"
+  recommendation
+  "The actions intended to resolve the risk."
+  planned
+  "This remediation activities were performed to address the risk."
+  completed
+}
 
-  "Defines the set of risk impact levels"
-  enum RiskImpact {
-    "Expected to have multiple severe or catastrophic adverse effects organizational operations, assets, or individuals."
-    very_high
-    "Expected to have severe or catastrophic adverse effects on organizational operations, assets, or individuals."
-    high
-    "Expected to have serious adverse effect on organizational operations, assets, or individuals."
-    moderate
-    "Expected to have limited adverse effect on organizational operations, assets, or individuals."
-    low
-    "Expected to have negligible adverse effect on organizational operations, assets, or individuals."
-    very_low
-  }
+"Defines the set of risk impact levels"
+enum RiskImpact {
+  "Expected to have multiple severe or catastrophic adverse effects organizational operations, assets, or individuals."
+  very_high
+  "Expected to have severe or catastrophic adverse effects on organizational operations, assets, or individuals."
+  high
+  "Expected to have serious adverse effect on organizational operations, assets, or individuals."
+  moderate
+  "Expected to have limited adverse effect on organizational operations, assets, or individuals."
+  low
+  "Expected to have negligible adverse effect on organizational operations, assets, or individuals."
+  very_low
+}
 
-  "Defines the set of risk likelihood levels"
-  enum RiskLikelihood {
-    "Almost certain to occur."
-    very_high
-    "Highly likely to occur."
-    high
-    "somewhat likely to occur."
-    moderate
-    "unlikely to occur."
-    low
-    "highly unlikely to occur."
-    very_low
-  }
+"Defines the set of risk likelihood levels"
+enum RiskLikelihood {
+  "Almost certain to occur."
+  very_high
+  "Highly likely to occur."
+  high
+  "somewhat likely to occur."
+  moderate
+  "unlikely to occur."
+  low
+  "highly unlikely to occur."
+  very_low
+}
 
-  "Defines the set of risk levels"
-  enum RiskLevel {
-    "Expected to have multiple severe or catastrophic adverse effects organizational operations, assets, or individuals."
-    very_high
-    "Expected to have severe or catastrophic adverse effects on organizational operations, assets, or individuals."
-    high
-    "Expected to have serious adverse effect on organizational operations, assets, or individuals."
-    moderate
-    "Expected to have limited adverse effect on organizational operations, assets, or individuals."
-    low
-    "Expected to have negligible adverse effect on organizational operations, assets, or individuals."
-    very_low
-    "Unknown level of risk"
-    unknown
-  }
+"Defines the set of risk levels"
+enum RiskLevel {
+  "Expected to have multiple severe or catastrophic adverse effects organizational operations, assets, or individuals."
+  very_high
+  "Expected to have severe or catastrophic adverse effects on organizational operations, assets, or individuals."
+  high
+  "Expected to have serious adverse effect on organizational operations, assets, or individuals."
+  moderate
+  "Expected to have limited adverse effect on organizational operations, assets, or individuals."
+  low
+  "Expected to have negligible adverse effect on organizational operations, assets, or individuals."
+  very_low
+  "Unknown level of risk"
+  unknown
+}
 
-  "Defines the type of status for a risk"
-  enum RiskStatus {
-    "The risk has been identified."
-    open
-    "The identified risk is being investigated."
-    investigating
-    "Remediation activities are underway, but are not yet complete."
-    remediating
-    "A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval."
-    deviation_requested
-    "A risk deviation, such as false positive, risk reduction, or operational requirement has been approved."
-    deviation_approved
-    "The risk has been resolved."
-    closed
-  }
+"Defines the type of status for a risk"
+enum RiskStatus {
+  "The risk has been identified."
+  open
+  "The identified risk is being investigated."
+  investigating
+  "Remediation activities are underway, but are not yet complete."
+  remediating
+  "A risk deviation, such as false positive, risk reduction, or operational requirement has been submitted for approval."
+  deviation_requested
+  "A risk deviation, such as false positive, risk reduction, or operational requirement has been approved."
+  deviation_approved
+  "The risk has been resolved."
+  closed
+}
 
-  "Defines the type of tasks"
-  enum OscalTaskType {
-    "The task represents a planned milestone."
-    milestone
-    "The task represents a specific assessment action to be performed."
-    action
-  }
+"Defines the type of tasks"
+enum OscalTaskType {
+  "The task represents a planned milestone."
+  milestone
+  "The task represents a specific assessment action to be performed."
+  action
+}
 
-  "Defines types of subjects"
-  enum SubjectType {
-    "Component"
-    component
-    "Inventory Item"
-    inventory_item
-    "Location"
-    location
-    "Interview Party"
-    party
-    "User"
-    user
-    "Resource or Artifact"
-    resource
-  }
+"Defines types of subjects"
+enum SubjectType {
+  "Component"
+  component
+  "Inventory Item"
+  inventory_item
+  "Location"
+  location
+  "Interview Party"
+  party
+  "User"
+  user
+  "Resource or Artifact"
+  resource
+}
 
-    "Defines the unit of time for a period"
-  enum TimeUnit {
-    "The period of time is specified in seconds."
-    seconds
-    "The period of time is specified in minutes."
-    minutes
-    "The period of time is specified in hours."
-    hours
-    "The period of time is specified in days."
-    days
-    "The period of time is specified in months."
-    months
-    "The period of time is specified in years."
-    years
-  }
+"Defines the unit of time for a period"
+enum TimeUnit {
+  "The period of time is specified in seconds."
+  seconds
+  "The period of time is specified in minutes."
+  minutes
+  "The period of time is specified in hours."
+  hours
+  "The period of time is specified in days."
+  days
+  "The period of time is specified in months."
+  months
+  "The period of time is specified in years."
+  years
+}
 
-  "Defines the set of facet source systems"
-  enum FacetSourceSystem {
-    "http://csrc.nist.gov/oscal"
-    Oscal
-    "http://fedramp.gov"
-    FedRAMP
-    "http://cve.mitre.org"
-    Cve
-    "http://www.first.org/cvss/2.0"
-    Cvss2_0
-    "http://www.first.org/cvss/3.0"
-    Cvss3_0
-    "http://www.first.org/cvss/3.1"
-    Cvss3_1
-  }
+"Defines the set of facet source systems"
+enum FacetSourceSystem {
+  "http://csrc.nist.gov/oscal"
+  Oscal
+  "http://fedramp.gov"
+  FedRAMP
+  "http://cve.mitre.org"
+  Cve
+  "http://www.first.org/cvss/2.0"
+  Cvss2_0
+  "http://www.first.org/cvss/3.0"
+  Cvss3_0
+  "http://www.first.org/cvss/3.1"
+  Cvss3_1
+}
 
-  "Defines the set of risk severity level"
-  enum VulnerabilitySeverity {
-    "Vulnerability is exposed and exploitable, and its exploitation could result in severe impacts."
-    very_high
-    "Vulnerability is of high concern, based on the exposure of the vulnerability and ease of exploitation and/or on the severity of impacts that could result from its exploitation."
-    high
-    "Vulnerability is of moderate concern, based on the exposure of the vulnerability and ease of exploitation and/or on the severity of impacts that could result from its exploitation."
-    moderate
-    "Vulnerability is of minor concern, but effectiveness of remediation could be improved."
-    low
-    "Vulnerability is not of concern."
-    very_low
-  }
-
+"Defines the set of risk severity level"
+enum VulnerabilitySeverity {
+  "Vulnerability is exposed and exploitable, and its exploitation could result in severe impacts."
+  very_high
+  "Vulnerability is of high concern, based on the exposure of the vulnerability and ease of exploitation and/or on the severity of impacts that could result from its exploitation."
+  high
+  "Vulnerability is of moderate concern, based on the exposure of the vulnerability and ease of exploitation and/or on the severity of impacts that could result from its exploitation."
+  moderate
+  "Vulnerability is of minor concern, but effectiveness of remediation could be improved."
+  low
+  "Vulnerability is not of concern."
+  very_low
+}
 
 "Defines the set of OSCAL/FedRAMP Facet names"
 enum OscalFacetName {
@@ -2786,4 +2869,3 @@ enum Cvss3SecurityRequirements {
   "Not defined"
   not_defined
 }
-

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-results/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-results/typeDefs.graphql
@@ -1,49 +1,49 @@
-  "Defines identifying information about an individual finding."
-  type Finding implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Finding
-    "Identifies the name for this POA&M item."
-    name: String!
-    "Identifies a human-readable description of the POA&M item."
-    description: String!
-    "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
-    origins: [Origin]
-    # "Identifies an assessor's conclusions regarding the degree to which an objective is satisfied."
-    # target: FindingTarget
-    # "Identifies a reference to the implementation statement in the SSP to which this finding is related."
-    # implementation_statement: ImplementationStatement
-    "Relates the finding to a set of referenced observations that were used to determine the finding."
-    related_observations(first: Int, offset: Int): ObservationConnection
-    "Relates the finding to a set of referenced risks that were used to determine the finding."
-    related_risks(first: Int, offset: Int): RiskConnection
-  }
+"Defines identifying information about an individual finding."
+type Finding implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+  # Finding
+  "Identifies the name for this POA&M item."
+  name: String!
+  "Identifies a human-readable description of the POA&M item."
+  description: String!
+  "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
+  origins: [Origin]
+  # "Identifies an assessor's conclusions regarding the degree to which an objective is satisfied."
+  # target: FindingTarget
+  # "Identifies a reference to the implementation statement in the SSP to which this finding is related."
+  # implementation_statement: ImplementationStatement
+  "Relates the finding to a set of referenced observations that were used to determine the finding."
+  related_observations(first: Int, offset: Int): ObservationConnection
+  "Relates the finding to a set of referenced risks that were used to determine the finding."
+  related_risks(first: Int, offset: Int): RiskConnection
+}

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/component.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/resolvers/component.js
@@ -66,6 +66,11 @@ const componentResolvers = {
             continue
           }
 
+          if (!component.hasOwnProperty('operational_status')) {
+            console.warn(`[CYIO] CONSTRAINT-VIOLATION: (${dbName}) ${component.iri} missing field 'operational_status'; fixing`);
+            component.operational_status = 'operational';
+          }
+
           // filter out non-matching entries if a filter is to be applied
           if ('filters' in args && args.filters != null && args.filters.length > 0) {
             if (!filterValues(component, args.filters, args.filterMode) ) {
@@ -269,6 +274,44 @@ const componentResolvers = {
       } else {
         return [];
       }
+    },
+    responsible_roles: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.responsible_roles_iri === undefined) return []; 
+      const reducer = getCommonReducer("RESPONSIBLE-ROLE");
+      const results = [];
+      let sparqlQuery = selectAllResponsibleRoles(selectMap.getNode('node'), args, parent );
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select Referenced Responsible Roles",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response === undefined || response.length === 0) return null;
+
+      // Handle reporting Stardog Error
+      if (typeof (response) === 'object' && 'body' in response) {
+        throw new UserInputError(response.statusText, {
+          error_details: (response.body.message ? response.body.message : response.body),
+          error_code: (response.body.code ? response.body.code : 'N/A')
+        });
+      }
+
+      for (let item of response) {
+        results.push(reducer(item));
+      }
+
+      // check if there is data to be returned
+      if (results.length === 0 ) return [];
+      return results;
+    },
+    protocols: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.protocols_iri === undefined) return []; 
     },
   },
 } ;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/typeDefs.graphql
@@ -128,6 +128,9 @@
     description: String
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+    props: [Property]
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -158,17 +161,17 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
     "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
+    responsible_roles: [OscalResponsibleRole]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocol]
   }
   # Mutation Type
   input ComponentAddInput {
@@ -181,6 +184,9 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+    props: [PropertyAddInput]
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -211,13 +217,17 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocolAddInput]
   }
   # Ordering types
   enum ComponentsOrdering {
@@ -338,25 +348,24 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
     "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # Hardware
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
     "Identifies the identifier for the installation"
     installation_id: String
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRole]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocol]
   }
-
   input HardwareComponentAddInput {
     # Component
     "Indicates the type of the component"
@@ -367,6 +376,7 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props -----
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -397,20 +407,22 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
     # TODO: Need to model OSCAL Link with @rel value != reference as Relationships
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # Hardware
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
     "Identifies the identifier for the installation"
     installation_id: String
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocolAddInput]
   }
 
   # Pagination Types
@@ -502,6 +514,7 @@
     description: String
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -516,8 +529,6 @@
     version: String
     "Identifies date the component was released, such as a software release date or policy publication date."
     release_date: Timestamp
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
     "Indicates relative placement of component ('internal' or 'external') to the system."
     implementation_point: ImplementationPoint!
     "Identifies whether the asset can be check with an authenticated scan"
@@ -534,22 +545,24 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
     "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    # NetworkComponent
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     "Indicates the name assigned to the network"
     network_name: String!
     "Indicate the IP address range of the network"
     network_address_range: IpAddressRange
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRole]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocol]
   }
-
   input NetworkComponentAddInput {
     # Component
     "Indicates the type of the component"
@@ -560,6 +573,7 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -590,33 +604,33 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    # NetworkComponent
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     "Indicates the name assigned to the network"
     network_name: String!
     "Indicates the IPv4 address range of the network"
     network_ipv4_address_range: IpV4AddressRangeAddInput
     "Indicates the IPv6 address range of the network"
     network_ipv6_address_range: IpV6AddressRangeAddInput
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocolAddInput]
   }
-
   # Pagination Types
   type NetworkComponentConnection {
     pageInfo: PageInfo!
     edges: [NetworkComponentEdge]
   }
-
   type NetworkComponentEdge {
     cursor: String!
     node: NetworkComponent!
   }
-
   # Filtering Types
   input NetworkComponentsFiltering {
     key: NetworkComponentsFilter!
@@ -624,7 +638,6 @@
     operator: String
     filterMode: FilterMode
   }
-
   enum NetworkComponentsOrdering {
     "Component Type"
     component_type
@@ -641,7 +654,6 @@
     "Network ID"
     network_id
   }
-
   enum NetworkComponentsFilter {
     "Component Type"
     component_type
@@ -661,7 +673,7 @@
 
 #####   Service Component 
 ##
-"Defines identifying information about a Service Component"
+  "Defines identifying information about a Service Component"
   type ServiceComponent implements BasicObject & LifecycleObject & OscalObject {
     # BasicObject
     "Uniquely identifies this object."
@@ -703,6 +715,7 @@
     description: String
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -733,23 +746,20 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+    physical_location: [OscalLocation]
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
     "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # ServiceComponent
+    responsible_roles: [OscalResponsibleRole]
     "Identifies information about the protocol used to provide a service."
-    ports: [PortInfo]
+    protocols: [ServiceProtocol]
   }
-
   input ServiceComponentAddInput {
     # Component
     "Indicates the type of the component"
@@ -760,6 +770,7 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -790,19 +801,18 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # ServiceComponent
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
     "Identifies information about the protocol used to provide a service."
-    ports: [PortInfoAddInput]
+    protocols: [ServiceProtocolAddInput]
   }
-
   # Pagination Types
   type ServiceComponentConnection {
     pageInfo: PageInfo!
@@ -893,6 +903,7 @@
     description: String
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # ---- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -923,19 +934,12 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
     "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # SoftwareComponent
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     cpe_identifier: String
     "Identifies the Software Identifier (SwID)"
     software_identifier: String
@@ -945,6 +949,13 @@
     installation_id: String
     "Identifies the license key"
     license_key: String
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRole]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocol]
   }
 
   input SoftwareComponentAddInput {
@@ -957,6 +968,7 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -987,15 +999,10 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # SoftwareComponent
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
     "Identifies the CPE identifier"
     cpe_identifier: String
     "Identifies the Software Identifier (SwID)"
@@ -1006,6 +1013,13 @@
     installation_id: String
     "Identifies the license key"
     license_key: String
+    # -- end props ---
+    "Indicates the operational status of the system component."
+    operational_status: OperationalStatus!
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocolAddInput]
   }
 
   # Pagination Types
@@ -1056,7 +1070,7 @@
 
 #####   System Component 
 ##
-"Defines identifying information about a System Component"
+  "Defines identifying information about a System Component"
   type SystemComponent implements BasicObject & LifecycleObject & OscalObject {
     # BasicObject
     "Uniquely identifies this object."
@@ -1098,6 +1112,7 @@
     description: String
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -1128,19 +1143,19 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+    physical_location: [OscalLocation]
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
     "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleParty]
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # SystemComponent
+    responsible_roles: [OscalResponsibleRole]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocol]
   }
 
   input SystemComponentAddInput {
@@ -1153,6 +1168,7 @@
     description: String!
     "Identifies a summary of the technological or business purpose of the component."
     purpose: String
+    # --- props ---
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
     asset_id: String
     "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
@@ -1183,28 +1199,27 @@
     baseline_configuration_name: String
     "Identifies the function provided by the asset for the system."
     function: String
+    "Identifies the related leveraged-authorization assembly in this SSP."
+    leveraged_authorization: String
+    "Identifies the component as it was assigned in the leveraged system's SSP."
+    inherited_identifier: String
+    # -- end props ---
     "Indicates the operational status of the system component."
     operational_status: OperationalStatus!
-    # TODO:  These SHOULD be references to the entities, not just their UUID/identifier
-    # "Identifies the related leveraged-authorization assembly in this SSP."
-    # leveraged_authorization: String
-    # "Identifies the component as it was assigned in the leveraged system's SSP."
-    # inherited_identifier: String
-    #
-    # SystemComponent
+    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_roles: [OscalResponsibleRoleAddInput]
+    "Identifies information about the protocol used to provide a service."
+    protocols: [ServiceProtocolAddInput]
   }
-
   # Pagination Types
   type SystemComponentConnection {
     pageInfo: PageInfo!
     edges: [SystemComponentEdge]
   }
-
   type SystemComponentEdge {
     cursor: String!
     node: SystemComponent!
   }
-
   # Filtering Types
   input SystemComponentsFiltering {
     key: SystemComponentsFilter!
@@ -1212,7 +1227,6 @@
     operator: String
     filterMode: FilterMode
   }
-
   enum SystemComponentsOrdering {
     "Component Type"
     component_type
@@ -1223,7 +1237,6 @@
     "Label"
     labels
   }
-
   enum SystemComponentsFilter {
     "Component Type"
     component_type
@@ -1233,6 +1246,65 @@
     modified
     "Label"
     label_name
+  }
+
+##### OSCAL ServiceProtocol
+##
+  "Defines information about the protocol used to provide a service."
+  type ServiceProtocol implements ComplexDatatype {
+    # ComplexDatatype
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    # OSCAL ServiceProtocol
+    "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
+    protocol_name: NetworkAssetProtocol!
+    "Identifies a human-readable name for the protocol."
+    name: String
+    "Identifies the IPv4 port range on which the service operations."
+    port_ranges: [ServicePortRange]
+  }
+  input ServiceProtocolAddInput {
+    # OSCAL ServiceProtocol
+    "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
+    protocol_name: NetworkAssetProtocol!
+    "Identifies a human-readable name for the protocol."
+    name: String
+    "Identifies the IPv4 port range on which the service operations."
+    port_ranges: [ServicePortRangeAddInput]
+  }
+
+##### OSCAL ServicePortRange
+##
+  type ServicePortRange implements ComplexDatatype {
+    # ComplexDatatype
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    # OSCAL Port-range
+    "Indicates the starting port number in a port range."
+    start: Int
+    "Indicates the ending port number in a port range."
+    end: Int
+    "Indicates the transport type."
+    transport: TransportType
+  }
+  input ServicePortRangeAddInput {
+    "Indicates the starting port number in a port range."
+    start: Int
+    "Indicates the ending port number in a port range."
+    end: Int
+    "Indicates the transport type."
+    transport: TransportType
+  }
+  "Defines the types of transports"
+  enum TransportType {
+    "Transmission Control Protocol"
+    TCP
+    "User Datagram Protocol"
+    UDP
   }
 
   union ComponentTypes = HardwareComponent | NetworkComponent | ServiceComponent | SoftwareComponent | SystemComponent

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/component/typeDefs.graphql
@@ -1,1343 +1,1380 @@
-  # declares the query entry-points for this type
-  extend type Query {
-    component(id: ID!): Component
-    componentList( 
-        first: Int
-        offset: Int
-        orderedBy: ComponentsOrdering
-        orderMode: OrderingMode
-        filters: [ComponentsFiltering]
-        filterMode: FilterMode
-        search: String
-      ): ComponentConnection
-    hardwareComponent(id: ID!): HardwareComponent
-    hardwareComponentList( 
-      first: Int
-      offset: Int
-      orderedBy: HardwareComponentsOrdering
-      orderMode: OrderingMode
-      filters: [HardwareComponentsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): HardwareComponentConnection
-    networkComponent(id: ID!): NetworkComponent
-    networkComponentList( 
-      first: Int
-      offset: Int
-      orderedBy: NetworkComponentsOrdering
-      orderMode: OrderingMode
-      filters: [NetworkComponentsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): NetworkComponentConnection
-    serviceComponent(id: ID!): ServiceComponent
-    serviceComponentList( 
-      first: Int
-      offset: Int
-      orderedBy: ServiceComponentsOrdering
-      orderMode: OrderingMode
-      filters: [ServiceComponentsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): ServiceComponentConnection
-    softwareComponent(id: ID!): SoftwareComponent
-    softwareComponentList( 
-      first: Int
-      offset: Int
-      orderedBy: SoftwareComponentsOrdering
-      orderMode: OrderingMode
-      filters: [SoftwareComponentsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): SoftwareComponentConnection
-    systemComponent(id: ID!): SystemComponent
-    systemComponentList( 
-      first: Int
-      offset: Int
-      orderedBy: SystemComponentsOrdering
-      orderMode: OrderingMode
-      filters: [SystemComponentsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): SystemComponentConnection
-  }
-
-  # declares the mutation entry-points for this type
-  extend type Mutation {
-    createComponent(input: ComponentAddInput): Component
-    deleteComponent(id: ID!): String!
-    editComponent(id: ID!, input: [EditInput]!, commitMessage: String): Component
-    createHardwareComponent( input: HardwareComponentAddInput ): HardwareComponent
-    deleteHardwareComponent( id: ID! ): String!
-    editHardwareComponent(id: ID!, input: [EditInput]!, commitMessage: String): HardwareComponent
-    createNetworkComponent( input: NetworkComponentAddInput ): NetworkComponent
-    deleteNetworkComponent( id: ID! ): String!
-    editNetworkComponent(id: ID!, input: [EditInput]!, commitMessage: String): NetworkComponent
-    createServiceComponent( input: HardwareComponentAddInput ): ServiceComponent
-    deleteServiceComponent( id: ID! ): String!
-    editServiceComponent(id: ID!, input: [EditInput]!, commitMessage: String): ServiceComponent
-    createSoftwareComponent( input: SoftwareComponentAddInput ): SoftwareComponent
-    deleteSoftwareComponent( id: ID! ): String!
-    editSoftwareComponent(id: ID!, input: [EditInput]!, commitMessage: String): SoftwareComponent
-    createSystemComponent( input: SystemComponentAddInput ): SystemComponent
-    deleteSystemComponent( id: ID! ): String!
-    editSystemComponent(id: ID!, input: [EditInput]!, commitMessage: String): SystemComponent
+# declares the query entry-points for this type
+extend type Query {
+  component(id: ID!): Component
+  componentList(
+    first: Int
+    offset: Int
+    orderedBy: ComponentsOrdering
+    orderMode: OrderingMode
+    filters: [ComponentsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): ComponentConnection
+  # hardwareComponent(id: ID!): HardwareComponent
+  # hardwareComponentList(
+  #   first: Int
+  #   offset: Int
+  #   orderedBy: HardwareComponentsOrdering
+  #   orderMode: OrderingMode
+  #   filters: [HardwareComponentsFiltering]
+  #   filterMode: FilterMode
+  #   search: String
+  # ): HardwareComponentConnection
+  # networkComponent(id: ID!): NetworkComponent
+  # networkComponentList(
+  #   first: Int
+  #   offset: Int
+  #   orderedBy: NetworkComponentsOrdering
+  #   orderMode: OrderingMode
+  #   filters: [NetworkComponentsFiltering]
+  #   filterMode: FilterMode
+  #   search: String
+  # ): NetworkComponentConnection
+  # serviceComponent(id: ID!): ServiceComponent
+  # serviceComponentList(
+  #   first: Int
+  #   offset: Int
+  #   orderedBy: ServiceComponentsOrdering
+  #   orderMode: OrderingMode
+  #   filters: [ServiceComponentsFiltering]
+  #   filterMode: FilterMode
+  #   search: String
+  # ): ServiceComponentConnection
+  # softwareComponent(id: ID!): SoftwareComponent
+  # softwareComponentList(
+  #   first: Int
+  #   offset: Int
+  #   orderedBy: SoftwareComponentsOrdering
+  #   orderMode: OrderingMode
+  #   filters: [SoftwareComponentsFiltering]
+  #   filterMode: FilterMode
+  #   search: String
+  # ): SoftwareComponentConnection
+  # systemComponent(id: ID!): SystemComponent
+  # systemComponentList(
+  #   first: Int
+  #   offset: Int
+  #   orderedBy: SystemComponentsOrdering
+  #   orderMode: OrderingMode
+  #   filters: [SystemComponentsFiltering]
+  #   filterMode: FilterMode
+  #   search: String
+  # ): SystemComponentConnection
 }
 
-#####  Component 
+# declares the mutation entry-points for this type
+extend type Mutation {
+  createComponent(input: ComponentAddInput): Component
+  deleteComponent(id: ID!): String!
+  editComponent(id: ID!, input: [EditInput]!, commitMessage: String): Component
+  # createHardwareComponent(input: HardwareComponentAddInput): HardwareComponent
+  # deleteHardwareComponent(id: ID!): String!
+  # editHardwareComponent(
+  #   id: ID!
+  #   input: [EditInput]!
+  #   commitMessage: String
+  # ): HardwareComponent
+  # createNetworkComponent(input: NetworkComponentAddInput): NetworkComponent
+  # deleteNetworkComponent(id: ID!): String!
+  # editNetworkComponent(
+  #   id: ID!
+  #   input: [EditInput]!
+  #   commitMessage: String
+  # ): NetworkComponent
+  # createServiceComponent(input: HardwareComponentAddInput): ServiceComponent
+  # deleteServiceComponent(id: ID!): String!
+  # editServiceComponent(
+  #   id: ID!
+  #   input: [EditInput]!
+  #   commitMessage: String
+  # ): ServiceComponent
+  # createSoftwareComponent(input: SoftwareComponentAddInput): SoftwareComponent
+  # deleteSoftwareComponent(id: ID!): String!
+  # editSoftwareComponent(
+  #   id: ID!
+  #   input: [EditInput]!
+  #   commitMessage: String
+  # ): SoftwareComponent
+  # createSystemComponent(input: SystemComponentAddInput): SystemComponent
+  # deleteSystemComponent(id: ID!): String!
+  # editSystemComponent(
+  #   id: ID!
+  #   input: [EditInput]!
+  #   commitMessage: String
+  # ): SystemComponent
+}
+
+#####  Component
 ##
-  "Defines identifying information about an OSCAL component"
-  type Component implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
-    props: [Property]
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
-  # Mutation Type
-  input ComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
-    props: [PropertyAddInput]
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
-  # Ordering types
-  enum ComponentsOrdering {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Name"
-    name
-    "Label"
-    labels
-  }
-  # Filtering Types
-  input ComponentsFiltering {
-    key: ComponentsFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about an OSCAL component"
+type Component implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum ComponentsFilter {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Pagination Types
-  type ComponentConnection {
-    pageInfo: PageInfo!
-    edges: [ComponentEdge]
-  }
-  type ComponentEdge {
-    cursor: String!
-    node: Component!
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Component
+  "Indicates the type of the component"
+  component_type: ComponentType
+  "Identifies a human-readable name for the component"
+  name: String!
+  "Identifies a description of the component, including information about its function."
+  description: String
+  "Identifies a summary of the technological or business purpose of the component."
+  purpose: String
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [Property]
+  # --- props ---
+  # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+  # asset_id: String
+  # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+  # asset_tag: String
+  # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+  # asset_type: AssetType
+  # "Identifies the  model of the component."
+  # model: String
+  # "Identifies the name of the company or organization"
+  # vendor_name: String
+  # "Indicates the version of the component."
+  # version: String
+  # "Identifies date the component was released, such as a software release date or policy publication date."
+  # release_date: Timestamp
+  # "Indicates relative placement of component ('internal' or 'external') to the system."
+  # implementation_point: ImplementationPoint!
+  # "Identifies whether the asset can be check with an authenticated scan"
+  # allows_authenticated_scans: Boolean
+  # "Identifies whether the asset is publicly accessible"
+  # is_publicly_accessible: Boolean
+  # "Identifies whether the asset is virtualized"
+  # is_virtual: Boolean
+  # "Identifies the network identifier of the asset."
+  # network_id: String
+  # "Identifies the Virtual LAN identifier of the asset."
+  # vlan_id: String
+  # "Identifies The name of the baseline configuration for the asset."
+  # baseline_configuration_name: String
+  # "Identifies the function provided by the asset for the system."
+  # function: String
+  # "Identifies the related leveraged-authorization assembly in this SSP."
+  # leveraged_authorization: String
+  # "Identifies the component as it was assigned in the leveraged system's SSP."
+  # inherited_identifier: String
+  # -- end props ---
+  "Indicates the operational status of the system component."
+  operational_status: OperationalStatus!
+  "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_roles: [OscalResponsibleRole]
+  "Identifies information about the protocol used to provide a service."
+  protocols: [ServiceProtocol]
+}
+# Mutation Type
+input ComponentAddInput {
+  # Component
+  "Indicates the type of the component"
+  component_type: ComponentType!
+  "Identifies a human-readable name for the component"
+  name: String!
+  "Identifies a description of the component, including information about its function."
+  description: String!
+  "Identifies a summary of the technological or business purpose of the component."
+  purpose: String
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [PropertyAddInput]
+  # --- props ---
+  # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+  # asset_id: String
+  # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+  # asset_tag: String
+  # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+  # asset_type: AssetType!
+  # "Identifies the  model of the component."
+  # model: String
+  # "Identifies the name of the company or organization"
+  # vendor_name: String
+  # "Indicates the version of the component."
+  # version: String
+  # "Identifies date the component was released, such as a software release date or policy publication date."
+  # release_date: Timestamp
+  # "Indicates relative placement of component ('internal' or 'external') to the system."
+  # implementation_point: ImplementationPoint!
+  # "Identifies whether the asset can be check with an authenticated scan"
+  # allows_authenticated_scans: Boolean
+  # "Identifies whether the asset is publicly accessible"
+  # is_publicly_accessible: Boolean
+  # "Identifies whether the asset is virtualized"
+  # is_virtual: Boolean
+  # "Identifies the network identifier of the asset."
+  # network_id: String
+  # "Identifies the Virtual LAN identifier of the asset."
+  # vlan_id: String
+  # "Identifies The name of the baseline configuration for the asset."
+  # baseline_configuration_name: String
+  # "Identifies the function provided by the asset for the system."
+  # function: String
+  # "Identifies the related leveraged-authorization assembly in this SSP."
+  # leveraged_authorization: String
+  # "Identifies the component as it was assigned in the leveraged system's SSP."
+  # inherited_identifier: String
+  # -- end props ---
+  "Indicates the operational status of the system component."
+  operational_status: OperationalStatus!
+  "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_roles: [OscalResponsibleRoleAddInput]
+  "Identifies information about the protocol used to provide a service."
+  protocols: [ServiceProtocolAddInput]
+}
+# Ordering types
+enum ComponentsOrdering {
+  "Component Type"
+  component_type
+  # "Asset Type"
+  # asset_type
+  "Created"
+  created
+  "Modified"
+  modified
+  "Name"
+  name
+  "Label"
+  label_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input ComponentsFiltering {
+  key: ComponentsFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum ComponentsFilter {
+  "Component Type"
+  component_type
+  # "Asset Type"
+  # asset_type
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+}
+# Pagination Types
+type ComponentConnection {
+  pageInfo: PageInfo!
+  edges: [ComponentEdge]
+}
+type ComponentEdge {
+  cursor: String!
+  node: Component!
+}
 
-
-#####   Hardware Component 
+#####   Hardware Component
 ##
-  "Defines identifying information about an OSCAL hardware component"
-  type HardwareComponent implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    "Identifies the identifier for the installation"
-    installation_id: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
-  input HardwareComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props -----
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    # TODO: Need to model OSCAL Link with @rel value != reference as Relationships
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    "Identifies the identifier for the installation"
-    installation_id: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
+# "Defines identifying information about an OSCAL hardware component"
+# type HardwareComponent implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # "Identifies the identifier for the installation"
+#   # installation_id: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRole]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocol]
+# }
+# input HardwareComponentAddInput {
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String!
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [PropertyAddInput]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # # TODO: Need to model OSCAL Link with @rel value != reference as Relationships
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # "Identifies the identifier for the installation"
+#   # installation_id: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRoleAddInput]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocolAddInput]
+# }
+# # Pagination Types
+# type HardwareComponentConnection {
+#   pageInfo: PageInfo!
+#   edges: [HardwareComponentEdge]
+# }
+# type HardwareComponentEdge {
+#   cursor: String!
+#   node: HardwareComponent!
+# }
+# # Filtering Types
+# input HardwareComponentsFiltering {
+#   key: HardwareComponentsFilter!
+#   values: [String]!
+#   operator: String
+#   filterMode: FilterMode
+# }
+# enum HardwareComponentsOrdering {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+#   "Marking"
+#   marking
+# }
+# enum HardwareComponentsFilter {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+# }
 
-  # Pagination Types
-  type HardwareComponentConnection {
-    pageInfo: PageInfo!
-    edges: [HardwareComponentEdge]
-  }
-
-  type HardwareComponentEdge {
-    cursor: String!
-    node: HardwareComponent!
-  }
-
-  # Filtering Types
-  input HardwareComponentsFiltering {
-    key: HardwareComponentsFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-
-  enum HardwareComponentsOrdering {
-    "Conmponent Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    labels
-  }
-
-  enum HardwareComponentsFilter {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-
-
-#####   Network Component 
+#####   Network Component
 ##
-  type NetworkComponent implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    "Indicates the name assigned to the network"
-    network_name: String!
-    "Indicate the IP address range of the network"
-    network_address_range: IpAddressRange
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
-  input NetworkComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    "Indicates the name assigned to the network"
-    network_name: String!
-    "Indicates the IPv4 address range of the network"
-    network_ipv4_address_range: IpV4AddressRangeAddInput
-    "Indicates the IPv6 address range of the network"
-    network_ipv6_address_range: IpV6AddressRangeAddInput
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
-  # Pagination Types
-  type NetworkComponentConnection {
-    pageInfo: PageInfo!
-    edges: [NetworkComponentEdge]
-  }
-  type NetworkComponentEdge {
-    cursor: String!
-    node: NetworkComponent!
-  }
-  # Filtering Types
-  input NetworkComponentsFiltering {
-    key: NetworkComponentsFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum NetworkComponentsOrdering {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    labels
-    "Network Name"
-    network_name
-    "Network ID"
-    network_id
-  }
-  enum NetworkComponentsFilter {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_nane
-    "Network Name"
-    network_name
-    "Network ID"
-    network_id
-  }
+# type NetworkComponent implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # "Indicates the name assigned to the network"
+#   # network_name: String!
+#   # "Indicate the IP address range of the network"
+#   # network_address_range: IpAddressRange
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRole]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocol]
+# }
+# input NetworkComponentAddInput {
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String!
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [PropertyAddInput]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # "Indicates the name assigned to the network"
+#   # network_name: String!
+#   # "Indicates the IPv4 address range of the network"
+#   # network_ipv4_address_range: IpV4AddressRangeAddInput
+#   # "Indicates the IPv6 address range of the network"
+#   # network_ipv6_address_range: IpV6AddressRangeAddInput
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRoleAddInput]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocolAddInput]
+# }
+# # Pagination Types
+# type NetworkComponentConnection {
+#   pageInfo: PageInfo!
+#   edges: [NetworkComponentEdge]
+# }
+# type NetworkComponentEdge {
+#   cursor: String!
+#   node: NetworkComponent!
+# }
+# # Filtering Types
+# input NetworkComponentsFiltering {
+#   key: NetworkComponentsFilter!
+#   values: [String]!
+#   operator: String
+#   filterMode: FilterMode
+# }
+# enum NetworkComponentsOrdering {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+#   "Network Name"
+#   network_name
+#   "Network ID"
+#   network_id
+#   "Marking"
+#   marking
+# }
+# enum NetworkComponentsFilter {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_nane
+#   "Network Name"
+#   network_name
+#   "Network ID"
+#   network_id
+# }
 
-#####   Service Component 
+#####   Service Component
 ##
-  "Defines identifying information about a Service Component"
-  type ServiceComponent implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
-  input ServiceComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
-  # Pagination Types
-  type ServiceComponentConnection {
-    pageInfo: PageInfo!
-    edges: [ServiceComponentEdge]
-  }
+# "Defines identifying information about a Service Component"
+# type ServiceComponent implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRole]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocol]
+# }
+# input ServiceComponentAddInput {
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String!
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [PropertyAddInput]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRoleAddInput]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocolAddInput]
+# }
+# # Pagination Types
+# type ServiceComponentConnection {
+#   pageInfo: PageInfo!
+#   edges: [ServiceComponentEdge]
+# }
+# type ServiceComponentEdge {
+#   cursor: String!
+#   node: ServiceComponent!
+# }
+# # Filtering Types
+# input ServiceComponentsFiltering {
+#   key: ServiceComponentsFilter!
+#   values: [String]!
+#   operator: String
+#   filterMode: FilterMode
+# }
+# enum ServiceComponentsOrdering {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+#   "Marking"
+#   marking
+# }
+# enum ServiceComponentsFilter {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+# }
 
-  type ServiceComponentEdge {
-    cursor: String!
-    node: ServiceComponent!
-  }
-
-  # Filtering Types
-  input ServiceComponentsFiltering {
-    key: ServiceComponentsFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-
-  enum ServiceComponentsOrdering {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    labels
-  }
-
-  enum ServiceComponentsFilter {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-
-
-#####   Software Component 
+#####   Software Component
 ##
-  "Defines identifying information about a Software Component"
-  type SoftwareComponent implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # ---- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    cpe_identifier: String
-    "Identifies the Software Identifier (SwID)"
-    software_identifier: String
-    "Identifies the patch level"
-    patch_level: String
-    "Identifies the identifier for the installation"
-    installation_id: String
-    "Identifies the license key"
-    license_key: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
+# "Defines identifying information about a Software Component"
+# type SoftwareComponent implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # cpe_identifier: String
+#   # "Identifies the Software Identifier (SwID)"
+#   # software_identifier: String
+#   # "Identifies the patch level"
+#   # patch_level: String
+#   # "Identifies the identifier for the installation"
+#   # installation_id: String
+#   # "Identifies the license key"
+#   # license_key: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRole]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocol]
+# }
+# input SoftwareComponentAddInput {
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String!
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [PropertyAddInput]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # "Identifies the CPE identifier"
+#   # cpe_identifier: String
+#   # "Identifies the Software Identifier (SwID)"
+#   # software_identifier: String
+#   # "Identifies the patch level"
+#   # patch_level: String
+#   # "Identifies the identifier for the installation"
+#   # installation_id: String
+#   # "Identifies the license key"
+#   # license_key: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRoleAddInput]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocolAddInput]
+# }
+# # Pagination Types
+# type SoftwareComponentConnection {
+#   pageInfo: PageInfo!
+#   edges: [SoftwareComponentEdge]
+# }
+# type SoftwareComponentEdge {
+#   cursor: String!
+#   node: SoftwareComponent!
+# }
+# # Filtering Types
+# input SoftwareComponentsFiltering {
+#   key: SoftwareComponentsFilter!
+#   values: [String]!
+#   operator: String
+#   filterMode: FilterMode
+# }
+# enum SoftwareComponentsOrdering {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+#   "Marking"
+#   marking
+# }
+# enum SoftwareComponentsFilter {
+#   "Component Type"
+#   component_type
+#   # "Asset Type"
+#   # asset_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+# }
 
-  input SoftwareComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    "Identifies the CPE identifier"
-    cpe_identifier: String
-    "Identifies the Software Identifier (SwID)"
-    software_identifier: String
-    "Identifies the patch level"
-    patch_level: String
-    "Identifies the identifier for the installation"
-    installation_id: String
-    "Identifies the license key"
-    license_key: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
-
-  # Pagination Types
-  type SoftwareComponentConnection {
-    pageInfo: PageInfo!
-    edges: [SoftwareComponentEdge]
-  }
-
-  type SoftwareComponentEdge {
-    cursor: String!
-    node: SoftwareComponent!
-  }
-
-  # Filtering Types
-  input SoftwareComponentsFiltering {
-    key: SoftwareComponentsFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-
-  enum SoftwareComponentsOrdering {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    labels
-  }
-
-  enum SoftwareComponentsFilter {
-    "Component Type"
-    component_type
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-
-
-#####   System Component 
+#####   System Component
 ##
-  "Defines identifying information about a System Component"
-  type SystemComponent implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRole]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocol]
-  }
-
-  input SystemComponentAddInput {
-    # Component
-    "Indicates the type of the component"
-    component_type: ComponentType!
-    "Identifies a human-readable name for the component"
-    name: String!
-    "Identifies a description of the component, including information about its function."
-    description: String!
-    "Identifies a summary of the technological or business purpose of the component."
-    purpose: String
-    # --- props ---
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
-    asset_tag: String
-    "Indicates the asset's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies the  model of the component."
-    model: String
-    "Identifies the name of the company or organization"
-    vendor_name: String
-    "Indicates the version of the component."
-    version: String
-    "Identifies date the component was released, such as a software release date or policy publication date."
-    release_date: Timestamp
-    "Indicates relative placement of component ('internal' or 'external') to the system."
-    implementation_point: ImplementationPoint!
-    "Identifies whether the asset can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the asset is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Identifies whether the asset is virtualized"
-    is_virtual: Boolean
-    "Identifies the network identifier of the asset."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the asset."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the asset."
-    baseline_configuration_name: String
-    "Identifies the function provided by the asset for the system."
-    function: String
-    "Identifies the related leveraged-authorization assembly in this SSP."
-    leveraged_authorization: String
-    "Identifies the component as it was assigned in the leveraged system's SSP."
-    inherited_identifier: String
-    # -- end props ---
-    "Indicates the operational status of the system component."
-    operational_status: OperationalStatus!
-    "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_roles: [OscalResponsibleRoleAddInput]
-    "Identifies information about the protocol used to provide a service."
-    protocols: [ServiceProtocolAddInput]
-  }
-  # Pagination Types
-  type SystemComponentConnection {
-    pageInfo: PageInfo!
-    edges: [SystemComponentEdge]
-  }
-  type SystemComponentEdge {
-    cursor: String!
-    node: SystemComponent!
-  }
-  # Filtering Types
-  input SystemComponentsFiltering {
-    key: SystemComponentsFilter!
-    values: [String]!
-    operator: String
-    filterMode: FilterMode
-  }
-  enum SystemComponentsOrdering {
-    "Component Type"
-    component_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    labels
-  }
-  enum SystemComponentsFilter {
-    "Component Type"
-    component_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
+# "Defines identifying information about a System Component"
+# type SystemComponent implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Indicates the physical location of the asset's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRole]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocol]
+# }
+# input SystemComponentAddInput {
+#   # Component
+#   "Indicates the type of the component"
+#   component_type: ComponentType!
+#   "Identifies a human-readable name for the component"
+#   name: String!
+#   "Identifies a description of the component, including information about its function."
+#   description: String!
+#   "Identifies a summary of the technological or business purpose of the component."
+#   purpose: String
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [PropertyAddInput]
+#   # --- props ---
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible item."
+#   # asset_tag: String
+#   # "Indicates the asset's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies the  model of the component."
+#   # model: String
+#   # "Identifies the name of the company or organization"
+#   # vendor_name: String
+#   # "Indicates the version of the component."
+#   # version: String
+#   # "Identifies date the component was released, such as a software release date or policy publication date."
+#   # release_date: Timestamp
+#   # "Indicates relative placement of component ('internal' or 'external') to the system."
+#   # implementation_point: ImplementationPoint!
+#   # "Identifies whether the asset can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the asset is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Identifies whether the asset is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the network identifier of the asset."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the asset."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the asset."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the asset for the system."
+#   # function: String
+#   # "Identifies the related leveraged-authorization assembly in this SSP."
+#   # leveraged_authorization: String
+#   # "Identifies the component as it was assigned in the leveraged system's SSP."
+#   # inherited_identifier: String
+#   # -- end props ---
+#   "Indicates the operational status of the system component."
+#   operational_status: OperationalStatus!
+#   "Indicates references to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_roles: [OscalResponsibleRoleAddInput]
+#   "Identifies information about the protocol used to provide a service."
+#   protocols: [ServiceProtocolAddInput]
+# }
+# # Pagination Types
+# type SystemComponentConnection {
+#   pageInfo: PageInfo!
+#   edges: [SystemComponentEdge]
+# }
+# type SystemComponentEdge {
+#   cursor: String!
+#   node: SystemComponent!
+# }
+# # Filtering Types
+# input SystemComponentsFiltering {
+#   key: SystemComponentsFilter!
+#   values: [String]!
+#   operator: String
+#   filterMode: FilterMode
+# }
+# enum SystemComponentsOrdering {
+#   "Component Type"
+#   component_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+#   "Marking"
+#   marking
+# }
+# enum SystemComponentsFilter {
+#   "Component Type"
+#   component_type
+#   "Created"
+#   created
+#   "Modified"
+#   modified
+#   "Label"
+#   label_name
+# }
 
 ##### OSCAL ServiceProtocol
 ##
-  "Defines information about the protocol used to provide a service."
-  type ServiceProtocol implements ComplexDatatype {
-    # ComplexDatatype
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    # OSCAL ServiceProtocol
-    "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
-    protocol_name: NetworkAssetProtocol!
-    "Identifies a human-readable name for the protocol."
-    name: String
-    "Identifies the IPv4 port range on which the service operations."
-    port_ranges: [ServicePortRange]
-  }
-  input ServiceProtocolAddInput {
-    # OSCAL ServiceProtocol
-    "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
-    protocol_name: NetworkAssetProtocol!
-    "Identifies a human-readable name for the protocol."
-    name: String
-    "Identifies the IPv4 port range on which the service operations."
-    port_ranges: [ServicePortRangeAddInput]
-  }
+"Defines information about the protocol used to provide a service."
+type ServiceProtocol implements ComplexDatatype {
+  # ComplexDatatype
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  # OSCAL ServiceProtocol
+  "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
+  protocol_name: NetworkAssetProtocol!
+  "Identifies a human-readable name for the protocol."
+  name: String
+  "Identifies the IPv4 port range on which the service operations."
+  port_ranges: [ServicePortRange]
+}
+input ServiceProtocolAddInput {
+  # OSCAL ServiceProtocol
+  "Defines the common name of the protocol, which should be the appropriate 'service name' from the IANA Service Name and Transport Protocol Port Number Registry."
+  protocol_name: NetworkAssetProtocol!
+  "Identifies a human-readable name for the protocol."
+  name: String
+  "Identifies the IPv4 port range on which the service operations."
+  port_ranges: [ServicePortRangeAddInput]
+}
 
 ##### OSCAL ServicePortRange
 ##
-  type ServicePortRange implements ComplexDatatype {
-    # ComplexDatatype
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    # OSCAL Port-range
-    "Indicates the starting port number in a port range."
-    start: Int
-    "Indicates the ending port number in a port range."
-    end: Int
-    "Indicates the transport type."
-    transport: TransportType
-  }
-  input ServicePortRangeAddInput {
-    "Indicates the starting port number in a port range."
-    start: Int
-    "Indicates the ending port number in a port range."
-    end: Int
-    "Indicates the transport type."
-    transport: TransportType
-  }
-  "Defines the types of transports"
-  enum TransportType {
-    "Transmission Control Protocol"
-    TCP
-    "User Datagram Protocol"
-    UDP
-  }
+type ServicePortRange implements ComplexDatatype {
+  # ComplexDatatype
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  # OSCAL Port-range
+  "Indicates the starting port number in a port range."
+  start: Int
+  "Indicates the ending port number in a port range."
+  end: Int
+  "Indicates the transport type."
+  transport: TransportType
+}
+input ServicePortRangeAddInput {
+  "Indicates the starting port number in a port range."
+  start: Int
+  "Indicates the ending port number in a port range."
+  end: Int
+  "Indicates the transport type."
+  transport: TransportType
+}
+"Defines the types of transports"
+enum TransportType {
+  "Transmission Control Protocol"
+  TCP
+  "User Datagram Protocol"
+  UDP
+}
 
-  union ComponentTypes = HardwareComponent | NetworkComponent | ServiceComponent | SoftwareComponent | SystemComponent
+"Defines the types of components"
+enum ComponentType {
+  "Any guideline or recommendation."
+  guidance
+  "A physical device."
+  hardware
+  "A connection to something outside this system."
+  interconnection
+  "A physical or virtual network."
+  network
+  "A tangible asset used to provide physical protections or countermeasures."
+  physical
+  "An applicable plan."
+  plan
+  "An enforceable policy."
+  policy
+  "A list of steps or actions to take to achieve some end result."
+  process_procedure
+  " A service that may provide APIs."
+  service
+  "Any software, operating system, or firmware."
+  software
+  "Any organizational or industry standard."
+  standard
+  "An external system, which may be a leveraged system or the other side of an interconnection."
+  system
+  "The system as a whole."
+  this_system
+  "An external assessment performed on some other component, that has been validated by a third-party."
+  validation
+}
 
-  "Defines the types of components"
-  enum ComponentType {
-    "Any guideline or recommendation."
-    guidance
-    "A physical device."
-    hardware
-    "A connection to something outside this system."
-    interconnection
-    "A physical or virtual network."
-    network
-    "A tangible asset used to provide physical protections or countermeasures."
-    physical
-    "An applicable plan."
-    plan
-    "An enforceable policy."
-    policy
-    "A list of steps or actions to take to achieve some end result."
-    process_procedure
-    " A service that may provide APIs."
-    service
-    "Any software, operating system, or firmware."
-    software
-    "Any organizational or industry standard."
-    standard
-    "An external system, which may be a leveraged system or the other side of an interconnection."
-    system
-    "The system as a whole."
-    this_system
-    "An external assessment performed on some other component, that has been validated by a third-party."
-    validation
-  }
-
+# union ComponentTypes =
+#     HardwareComponent
+#   | NetworkComponent
+#   | ServiceComponent
+#   | SoftwareComponent
+#   | SystemComponent

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/inventoryItem.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/inventoryItem.js
@@ -10,7 +10,8 @@ import {
     deleteInventoryItemQuery,
     deleteInventoryItemByIriQuery,
     attachToInventoryItemQuery,
-    detachFromInventoryItemQuery
+    detachFromInventoryItemQuery,
+    convertAssetToInventoryItem,
 } from './sparql-query.js';
 
 const inventoryItemResolvers = {
@@ -43,7 +44,7 @@ const inventoryItemResolvers = {
 
       if (Array.isArray(response) && response.length > 0) {
         const edges = [];
-        const reducer = getReducer("INVENTORY-ITEM");
+        // const reducer = getReducer("INVENTORY-ITEM");
         let filterCount, resultCount, limit, offset, limitSize, offsetSize;
         limitSize = limit = (args.first === undefined ? response.length : args.first) ;
         offsetSize = offset = (args.offset === undefined ? 0 : args.offset) ;
@@ -74,11 +75,15 @@ const inventoryItemResolvers = {
             filterCount++;
           }
 
+          // convert the asset into a component
+          inventoryItem = convertAssetToInventoryItem(inventoryItem);
+
           // if haven't reached limit to be returned
           if (limit) {
             let edge = {
               cursor: inventoryItem.iri,
-              node: reducer(inventoryItem),
+              node: inventoryItem,
+              // node: reducer(inventoryItem),
             }
             edges.push(edge)
             limit--;
@@ -136,8 +141,8 @@ const inventoryItemResolvers = {
       }
 
       if (Array.isArray(response) && response.length > 0) {
-        const reducer = getReducer("INVENTORY-ITEM");
-        return reducer(response[0]);  
+        // convert the asset into a component
+        return convertAssetToInventoryItem(response[0]);
       }
     },
   },
@@ -306,6 +311,7 @@ const inventoryItemResolvers = {
       return results;
     },
     implemented_components: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.implemented_components !== undefined) return parent.implemented_components;
       if (parent.implemented_components_iri === undefined) return []; 
     },
   },

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/inventoryItem.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/inventoryItem.js
@@ -270,7 +270,47 @@ const inventoryItemResolvers = {
         return [];
       }
     },
+    responsible_parties: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.responsible_parties_iri === undefined) return []; 
+      const reducer = getCommonReducer("RESPONSIBLE-PARTY");
+      const results = [];
+      let sparqlQuery = selectAllResponsibleParties(selectMap.getNode('node'), args, parent );
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select Referenced Responsible Parties",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response === undefined || response.length === 0) return null;
+
+      // Handle reporting Stardog Error
+      if (typeof (response) === 'object' && 'body' in response) {
+        throw new UserInputError(response.statusText, {
+          error_details: (response.body.message ? response.body.message : response.body),
+          error_code: (response.body.code ? response.body.code : 'N/A')
+        });
+      }
+
+      for (let item of response) {
+        results.push(reducer(item));
+      }
+
+      // check if there is data to be returned
+      if (results.length === 0 ) return [];
+      return results;
+    },
+    implemented_components: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.implemented_components_iri === undefined) return []; 
+    },
   },
 } ;
+
+
 
 export default inventoryItemResolvers ;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/resolvers/sparql-query.js
@@ -5,6 +5,7 @@ import {
     generateId, 
     OSCAL_NS
   } from "../../../utils.js";
+import { selectOscalTaskByIriQuery } from "../../assessment-common/resolvers/sparql-query.js";
     
 // Utility functions
 export function getReducer( type ) {
@@ -138,7 +139,16 @@ export const selectInventoryItemByIriQuery = (iri, select) => {
 }
 export const selectAllInventoryItems = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(inventoryItemPredicateMap);
-  if (select.includes('props')) select = Object.keys(inventoryItemPredicateMap);
+  if (select.includes('props')) {
+    select = Object.keys(inventoryItemPredicateMap);
+    if (select.includes('label_name')) select = select.filter(i => i !== 'label_name');
+    if (select.includes('locations')) select = select.filter(i => i !== 'locations');
+    if (select.includes('installed_operating_system')) select = select.filter(i => i !== 'installed_operating_system');
+    if (select.includes('installed_software')) select = select.filter(i => i !== 'installed_software');
+    if (select.includes('ip_address')) select = select.filter(i => i !== 'ip_address');
+    if (select.includes('mac_address')) select = select.filter(i => i !== 'mac_address');
+    // if (select.includes('implemented_components')) delete select.implemented_components;
+  }
   if (!select.includes('id')) select.push('id');
   if (!select.includes('asset_type')) select.push('asset_type');
 
@@ -342,54 +352,59 @@ export const inventoryItemPredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "version");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  release_date: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#release_date>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:dateTime`: null, this.predicate, "release_date");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
-  implementation_point: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#implementation_point>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "implementation_point");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
-  operational_status: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#operational_status>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "operational_status");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
+  // release_date: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#release_date>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:dateTime`: null, this.predicate, "release_date");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
+  // implementation_point: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#implementation_point>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "implementation_point");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
+  // operational_status: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#operational_status>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "operational_status");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
   function: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#function>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "function");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  cpe_identifier: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#cpe_identifier>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "cpe_identifier");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
+  // cpe_identifier: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#cpe_identifier>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "cpe_identifier");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
   model: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#model>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "model")},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
   },
-  motherboard_id: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#motherboard_id>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "motherboard_id")},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
-  },
-  installation_id: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#installation_id>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installation_id");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
-  },
-  installed_hardware: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#installed_hardware>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_hardware");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
+  // motherboard_id: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#motherboard_id>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "motherboard_id")},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
+  // },
+  // installation_id: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#installation_id>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installation_id");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
+  // },
+  // installed_hardware: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#installed_hardware>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_hardware");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
   installed_operating_system: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#installed_operating_system>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_operating_system");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  installed_os_id: {
+    predicate: "<http://scap.nist.gov/ns/asset-identification#installed_operating_system>/<http://darklight.ai/ns/common#id>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_os_id");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
   installed_os_name: {
@@ -417,21 +432,21 @@ export const inventoryItemPredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"^^xsd:dateTime`: null, this.predicate, "last_scanned");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  bios_id: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#bios_id>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "bios_id")},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
-  },
+  // bios_id: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#bios_id>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "bios_id")},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
+  // },
   fqdn: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#fqdn>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "fqdn")},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
   },
-  hostname: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#hostname>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "hostname")},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
-  },
+  // hostname: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#hostname>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "hostname")},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
+  // },
   netbios_name: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#netbios_name>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "netbios_name")},
@@ -442,11 +457,11 @@ export const inventoryItemPredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "network_id")},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
   },
-  default_gateway: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#default_gateway>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "default_gateway")},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
-  },
+  // default_gateway: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#default_gateway>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "default_gateway")},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));}
+  // },
   vlan_id: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#vlan_id>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "vlan_id")},
@@ -460,6 +475,11 @@ export const inventoryItemPredicateMap = {
   installed_software: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#installed_software>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_software");},
+    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  },
+  installed_software_id: {
+    predicate: "<http://scap.nist.gov/ns/asset-identification#installed_software>/<http://darklight.ai/ns/common#id>",
+    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "installed_software_id");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
   installed_software_name: {
@@ -477,16 +497,16 @@ export const inventoryItemPredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip_address_value");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  ipv4_address: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#ip_address>", // this should really be ipv4_address in ontology
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip4_address");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
-  ipv6_address: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#ip_address>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip6_address");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
+  // ipv4_address: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#ip_address>", // this should really be ipv4_address in ontology
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip4_address");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
+  // ipv6_address: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#ip_address>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ip6_address");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
   mac_address: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#mac_address>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "mac_address");},
@@ -497,16 +517,16 @@ export const inventoryItemPredicateMap = {
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "mac_address_value");},
     optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
   },
-  ports: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#ports>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ports");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
-  connected_to_network: {
-    predicate: "<http://scap.nist.gov/ns/asset-identification#connected_to_network>",
-    binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "connected_to_network");},
-    optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
-  },
+  // ports: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#ports>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "ports");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
+  // connected_to_network: {
+  //   predicate: "<http://scap.nist.gov/ns/asset-identification#connected_to_network>",
+  //   binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "connected_to_network");},
+  //   optional: function (iri, value) { return optionalizePredicate(this.binding(iri, value));},
+  // },
   baseline_configuration_name: {
     predicate: "<http://scap.nist.gov/ns/asset-identification#baseline_configuration_name>",
     binding: function (iri, value) { return parameterizePredicate(iri, value ? `"${value}"` : null, this.predicate, "baseline_configuration_name")},
@@ -517,6 +537,7 @@ export const inventoryItemPredicateMap = {
 // Function to convert an Asset to a Component
 export function convertAssetToInventoryItem(asset) {
   let propList = [];
+  let implementedComponents = [];
   
   // Convert the each key/value pair of asset into an individual OSCAL Property objects
   for (let [key, value] of Object.entries(asset)) {
@@ -537,11 +558,8 @@ export function convertAssetToInventoryItem(asset) {
       case 'responsible_parties':
       case 'implemented_components':
       case 'connected_to_network':
-      case 'ip_address_value':
-      case 'installed_os_name':
-      case 'mac_address_value':
-      case 'installed_software_name':
-      case 'location_name':
+      // case 'installed_os_id':
+      // case 'installed_software_id':
           continue;
       case 'is_scanned':
       case 'allows_authenticated_scans':
@@ -555,15 +573,25 @@ export function convertAssetToInventoryItem(asset) {
         key = 'virtual';
         value = (value === true ? 'yes' : 'no');
         break;
-      case 'ip_address':                  // ip_address_value
+      // case 'ip_address':
+      case 'ip_address_value':
         key = (asset.ip_address_value.includes(':') ? 'ipv6-address' : 'ipv4-address');
         value = asset.ip_address_value;
         break;
-      case 'installed_operating_system':  // installed_os_name
+      // case 'installed_operating_system':
+      case 'installed_os_name':
         key = 'os-name';
         value = asset.installed_os_name;
         break;
-      case 'mac_address':                 // mac_address_value
+      case 'installed_os_id':
+        let implementedComponent = {
+          id: generateId(),
+          entity_type: 'implemented-component',
+          component_uuid: asset.installed_os_id[0],
+        }
+        implementedComponents.push(implementedComponent)
+        continue;
+      case 'mac_address_value':
         key = 'mac-address';
         if (!asset.mac_address_value.includes(':')) {
           value = asset.mac_address_value.replace(/([A-F0-9]{2})(?=[A-F0-9])/g, '$1:');
@@ -571,11 +599,25 @@ export function convertAssetToInventoryItem(asset) {
           value = asset.mac_address_value;
         }
         break;
-      case 'installed_software':          // installed_software_name
-        key = 'software-name';
-        value = asset.installed_software_name;
+      case 'installed_software_name':
+        if ('installed_software_name' in asset) {
+          key = 'software-name';
+          value = asset.installed_software_name;  
+        }
         break;
-      case 'location':
+      case 'installed_software_id':
+        // TODO: Should this be actually represented as 'implemented_components'?
+        //       Why not have the name, version, asset_type as a prop
+        for (let swId of asset.installed_software_id) {
+          let implementedComponent = {
+            id: generateId(),
+            entity_type: 'implemented-component',
+            component_uuid: swId,
+          }
+          implementedComponents.push(implementedComponent)
+        }
+        continue;
+      case 'location_name':
         key = 'physical-location';
         value = asset.location_name;
         break;
@@ -612,6 +654,7 @@ export function convertAssetToInventoryItem(asset) {
     props: propList,
     ...(asset.links && {links_iri: asset.links}),
     ...(asset.responsible_parties && {responsible_parties_iri: asset.responsible_parties}),
+    ...(implementedComponents.length > 0 && {implemented_components: implementedComponents}),
     ...(asset.implemented_components && {implemented_components_iri: asset.implemented_components}),
     ...(asset.remarks && {remarks_iri: asset.remarks}),
   };

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/typeDefs.graphql
@@ -1,864 +1,918 @@
-  # declares the query entry-points for this type
-  extend type Query {
-    inventoryItem(id: ID!): InventoryItem
-    inventoryItemList( 
-          first: Int
-          offset: Int
-          orderedBy: InventoryItemsOrdering
-          orderMode: OrderingMode
-          filters: [InventoryItemsFiltering]
-          filterMode: FilterMode
-          search: String
-        ): InventoryItemConnection
-  }
-
-  # declares the mutation entry-points for this type
-  extend type Mutation {
-    createInventoryItem(input: InventoryItemAddInput): InventoryItem
-    deleteInventoryItem(id: ID!): String!
-    editInventoryItem(id: ID!, input: [EditInput]!, commitMessage: String): InventoryItem
-  }
-
-
-#####   Inventory Item 
-##
-  "Defines identifying information about a single managed inventory item within the system."
-  type InventoryItem {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
-    props: [Property]
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-  # Mutation Types
-  input InventoryItemAddInput {
-    # Inventory Item
-    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
-    props: [PropertyAddInput]
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the inventory item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible inventory item."
-    asset_tag: String
-    "Indicates the serial number for the invenotry item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the inventory item, including information about its function."
-    description: String!
-    "Identifies the  model of the inventory item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item."
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4AddressAddInput]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6AddressAddInput]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsiblePartyAddInput]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [ComponentAddInput]
-}
-  # Ordering Types
-  enum InventoryItemsOrdering {
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Name"
-    name
-    "Label"
-    labels
-  }
-  # Filtering Types
-  input InventoryItemsFiltering {
-    key: InventoryItemFilter!
-    values: [String]!
-    operator: String
+# declares the query entry-points for this type
+extend type Query {
+  inventoryItem(id: ID!): InventoryItem
+  inventoryItemList(
+    first: Int
+    offset: Int
+    orderedBy: InventoryItemsOrdering
+    orderMode: OrderingMode
+    filters: [InventoryItemsFiltering]
     filterMode: FilterMode
-  }
-  enum InventoryItemFilter {
-    "Asset Type"
-    asset_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-  }
-  # Pagination Types
-  type InventoryItemConnection {
-    pageInfo: PageInfo!
-    edges: [InventoryItemEdge]
-  }
-  type InventoryItemEdge {
-    cursor: String!
-    node: InventoryItem!
-  }
+    search: String
+  ): InventoryItemConnection
+}
 
+# declares the mutation entry-points for this type
+extend type Mutation {
+  createInventoryItem(input: InventoryItemAddInput): InventoryItem
+  deleteInventoryItem(id: ID!): String!
+  editInventoryItem(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): InventoryItem
+}
+
+#####   Inventory Item
+##
+"Defines identifying information about a single managed inventory item within the system."
+type InventoryItem implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+  # Inventory Item
+  "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+  asset_type: AssetType
+  "Identifies the name of the inventory item."
+  name: String!
+  "Identifies a description of the Inventory Item, including information about its function."
+  description: String
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [Property]
+  # --- props ---
+  # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+  # asset_type: AssetType
+  # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+  # asset_id: String
+  # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+  # asset_tag: String
+  # "Indicates the serial number for the inventory item."
+  # serial_number: String
+  # "Identifies the model of the Inventory Item."
+  # model: String
+  # "Identifies the name of the company or organization that manufactured the inventory item"
+  # vendor_name: String
+  # "Identifies whether the inventory item can be check with an authenticated scan"
+  # allows_authenticated_scans: Boolean
+  # "Identifies whether the inventory item is publicly accessible"
+  # is_publicly_accessible: Boolean
+  # "Indicates if the inventory item is subjected to network scans"
+  # is_scanned: Boolean
+  # "Identifies whether the inventory item is virtualized"
+  # is_virtual: Boolean
+  # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+  # ipv4_address: [IpV4Address]
+  # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+  # ipv6_address: [IpV6Address]
+  # "Indicates the media access control (MAC) address for the inventory item."
+  # mac_address: [MAC]
+  # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+  # fqdn: String
+  # "Indicates the NetBIOS name for the inventory item."
+  # netbios_name: String
+  # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+  # uri: URL
+  # "Identifies the network identifier of the inventory item."
+  # network_id: String
+  # "Identifies the Virtual LAN identifier of the inventory item."
+  # vlan_id: String
+  # "Identifies The name of the baseline configuration for the inventory item."
+  # baseline_configuration_name: String
+  # "Identifies the function provided by the inventory item for the system."
+  # function: String
+  # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+  # physical_location: [OscalLocation]
+  # "Identifies the CPE identifier for a hardware device"
+  # cpe_identifier: String
+  # -- end props
+  "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_parties: [OscalResponsibleParty]
+  "Identifies the set of components that are implemented in a given system inventory item."
+  implemented_components: [ImplementedComponent]
+}
+# Mutation Types
+input InventoryItemAddInput {
+  "Identifies the name of the inventory item."
+  name: String!
+  "Identifies a description of the Inventory Item, including information about its function."
+  description: String
+  # Inventory Item
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [PropertyAddInput]
+  # --- props ---
+  # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+  # asset_type: AssetType!
+  # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the inventory item."
+  # asset_id: String
+  # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible inventory item."
+  # asset_tag: String
+  # "Indicates the serial number for the invenotry item."
+  # serial_number: String
+  # "Identifies the name of the inventory item."
+  # name: String!
+  # "Identifies a description of the inventory item, including information about its function."
+  # description: String!
+  # "Identifies the  model of the inventory item."
+  # model: String
+  # "Identifies the name of the company or organization that manufactured the inventory item."
+  # vendor_name: String
+  # "Identifies whether the inventory item can be check with an authenticated scan"
+  # allows_authenticated_scans: Boolean
+  # "Identifies whether the inventory item is publicly accessible"
+  # is_publicly_accessible: Boolean
+  # "Indicates if the inventory item is subjected to network scans"
+  # is_scanned: Boolean
+  # "Identifies whether the inventory item is virtualized"
+  # is_virtual: Boolean
+  # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+  # ipv4_address: [IpV4AddressAddInput]
+  # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+  # ipv6_address: [IpV6AddressAddInput]
+  # "Indicates the media access control (MAC) address for the inventory item."
+  # mac_address: [MAC]
+  # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+  # fqdn: String
+  # "Indicates the NetBIOS name for the inventory item."
+  # netbios_name: String
+  # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+  # uri: URL
+  # "Identifies the network identifier of the inventory item."
+  # network_id: String
+  # "Identifies the Virtual LAN identifier of the inventory item."
+  # vlan_id: String
+  # "Identifies The name of the baseline configuration for the inventory item."
+  # baseline_configuration_name: String
+  # "Identifies the function provided by the inventory item for the system."
+  # function: String
+  # "Identifies the CPE identifier for a hardware device"
+  # cpe_identifier: String
+  # -- end props
+  "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_parties: [OscalResponsiblePartyAddInput]
+  "Identifies the set of components that are implemented in a given system inventory item."
+  implemented_components: [ImplementedComponentAddInput]
+}
+# Ordering Types
+enum InventoryItemsOrdering {
+  "Asset Type"
+  asset_type
+  "Created"
+  created
+  "Modified"
+  modified
+  "Name"
+  name
+  "Label"
+  label_name
+  "Marking"
+  marking
+}
+# Filtering Types
+input InventoryItemsFiltering {
+  key: InventoryItemFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+enum InventoryItemFilter {
+  "Asset Type"
+  asset_type
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+}
+# Pagination Types
+type InventoryItemConnection {
+  pageInfo: PageInfo!
+  edges: [InventoryItemEdge]
+}
+type InventoryItemEdge {
+  cursor: String!
+  node: InventoryItem!
+}
 
 #####   Appliance
 ##
-  "Defines identifying information about an Appliance"
-  type Appliance implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Identifies the date and time the inventory item was last scanned"
-    last_scanned: Timestamp
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the identifier for the installation"
-    installation_id: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
+# "Defines identifying information about an Appliance"
+# type Appliance implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Identifies the date and time the inventory item was last scanned"
+#   # last_scanned: Timestamp
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the identifier for the installation"
+#   # installation_id: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Computing Device
 ##
-  "Defines identifying information about an Computing Device"
-  type ComputingDevice implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
+# "Defines identifying information about an Computing Device"
+# type ComputingDevice implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Firewall
 ##
-  "Defines identifying information about an Firewall"
-  type Firewall implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-}
+# "Defines identifying information about an Firewall"
+# type Firewall implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Hardware
 ##
-  "Defines identifying information about an Hardware"
-  type Hardware implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType!
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
+# "Defines identifying information about an Hardware"
+# type Hardware implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType!
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Network Device
 ##
-  "Defines identifying information about an Network Device"
-  type NetworkDevice implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
+# "Defines identifying information about an Network Device"
+# type NetworkDevice implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Router
 ##
-  "Defines identifying information about an Router"
-  type Router implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
+# "Defines identifying information about an Router"
+# type Router implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
 #####   Switch
 ##
-  "Defines identifying information about an Switch"
-  type Switch implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Inventory Item
-    # --- props ---
-    "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
-    asset_type: AssetType
-    "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
-    asset_id: String
-    "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
-    asset_tag: String
-    "Indicates the serial number for the inventory item."
-    serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
-    "Identifies the model of the Inventory Item."
-    model: String
-    "Identifies the name of the company or organization that manufactured the inventory item"
-    vendor_name: String
-    "Identifies whether the inventory item can be check with an authenticated scan"
-    allows_authenticated_scans: Boolean
-    "Identifies whether the inventory item is publicly accessible"
-    is_publicly_accessible: Boolean
-    "Indicates if the inventory item is subjected to network scans"
-    is_scanned: Boolean
-    "Identifies whether the inventory item is virtualized"
-    is_virtual: Boolean
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv4_address: [IpV4Address]
-    "Indicates the Internet Protocol v4 Addresses of the inventory item"
-    ipv6_address: [IpV6Address]
-    "Indicates the media access control (MAC) address for the inventory item."
-    mac_address: [MAC]
-    "Indicates the full-qualified domain name (FQDN) of the inventory item."
-    fqdn: String
-    "Indicates the NetBIOS name for the inventory item."
-    netbios_name: String
-    "Indicates the Uniform Resource Identifier (URI) for the inventory item."
-    uri: URL
-    "Identifies the network identifier of the inventory item."
-    network_id: String
-    "Identifies the Virtual LAN identifier of the inventory item."
-    vlan_id: String
-    "Identifies The name of the baseline configuration for the inventory item."
-    baseline_configuration_name: String
-    "Identifies the function provided by the inventory item for the system."
-    function: String
-    "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
-    physical_location: [OscalLocation]
-    "Identifies the CPE identifier for a hardware device"
-    cpe_identifier: String
-    # -- end props
-    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
-    responsible_parties: [OscalResponsibleParty]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
-  }
-
-  union InventoryItemTypes = Hardware 
-          | ComputingDevice | Appliance
-          | NetworkDevice | Firewall | Router | Switch
+# "Defines identifying information about an Switch"
+# type Switch implements BasicObject & LifecycleObject & OscalObject {
+#   # BasicObject
+#   "Uniquely identifies this object."
+#   id: ID!
+#   "Identifies the identifier defined by the standard."
+#   standard_id: String!
+#   "Identifies the type of the Object."
+#   entity_type: String!
+#   "Identifies the parent types of this object."
+#   parent_types: [String]!
+#   # CoreObject
+#   "Indicates the date and time at which the object was originally created."
+#   created: Timestamp
+#   "Indicates the date and time that this particular version of the object was last modified."
+#   modified: Timestamp
+#   "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+#   labels: [CyioLabel]
+#   # OscalObject
+#   "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+#   links: [CyioExternalReference]
+#   "Identifies one or more references to additional commentary on the Model."
+#   remarks: [CyioNote]
+#   "Identifies one or more relationships to other entities."
+#   relationships(
+#     first: Int
+#     offset: Int
+#     orderedBy: OscalRelationshipsOrdering
+#     orderMode: OrderingMode
+#     filters: [OscalRelationshipsFiltering]
+#     filterMode: FilterMode
+#     search: String
+#   ): OscalRelationshipConnection
+#   # Inventory Item
+#   "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+#   props: [Property]
+#   # --- props ---
+#   # "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
+#   # asset_type: AssetType
+#   # "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
+#   # asset_id: String
+#   # "Identifies an asset tag assigned by the organization responsible for maintaining the logical or tangible invenotry item."
+#   # asset_tag: String
+#   # "Indicates the serial number for the inventory item."
+#   # serial_number: String
+#   # "Identifies the name of the inventory item."
+#   # name: String!
+#   # "Identifies a description of the Inventory Item, including information about its function."
+#   # description: String
+#   # "Identifies the model of the Inventory Item."
+#   # model: String
+#   # "Identifies the name of the company or organization that manufactured the inventory item"
+#   # vendor_name: String
+#   # "Identifies whether the inventory item can be check with an authenticated scan"
+#   # allows_authenticated_scans: Boolean
+#   # "Identifies whether the inventory item is publicly accessible"
+#   # is_publicly_accessible: Boolean
+#   # "Indicates if the inventory item is subjected to network scans"
+#   # is_scanned: Boolean
+#   # "Identifies whether the inventory item is virtualized"
+#   # is_virtual: Boolean
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv4_address: [IpV4Address]
+#   # "Indicates the Internet Protocol v4 Addresses of the inventory item"
+#   # ipv6_address: [IpV6Address]
+#   # "Indicates the media access control (MAC) address for the inventory item."
+#   # mac_address: [MAC]
+#   # "Indicates the full-qualified domain name (FQDN) of the inventory item."
+#   # fqdn: String
+#   # "Indicates the NetBIOS name for the inventory item."
+#   # netbios_name: String
+#   # "Indicates the Uniform Resource Identifier (URI) for the inventory item."
+#   # uri: URL
+#   # "Identifies the network identifier of the inventory item."
+#   # network_id: String
+#   # "Identifies the Virtual LAN identifier of the inventory item."
+#   # vlan_id: String
+#   # "Identifies The name of the baseline configuration for the inventory item."
+#   # baseline_configuration_name: String
+#   # "Identifies the function provided by the inventory item for the system."
+#   # function: String
+#   # "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
+#   # physical_location: [OscalLocation]
+#   # "Identifies the CPE identifier for a hardware device"
+#   # cpe_identifier: String
+#   # -- end props
+#   "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+#   responsible_parties: [OscalResponsibleParty]
+#   "Identifies the set of components that are implemented in a given system inventory item."
+#   implemented_components: [Component]
+# }
+##### ImplementedComponent
+##
+"Defines identify information for the set of components that are implemented in a given system inventory item. "
+type ImplementedComponent implements ComplexDatatype {
+  # ComplexDatatype
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  # OSCAL ImplementedComponent
+  "Identifies a machine-oriented identifier reference to a component that is implemented as part of an inventory item."
+  component_uuid: ID!
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [Property]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_parties: [OscalResponsibleParty]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+}
+input ImplementedComponentAddInput {
+  "Identifies a machine-oriented identifier reference to a component that is implemented as part of an inventory item."
+  component_uuid: ID!
+  "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  props: [PropertyAddInput]
+  "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+  responsible_parties: [OscalResponsiblePartyAddInput]
+}
+##### Union Definitions
+##
+# union InventoryItemTypes =
+#     Hardware
+#   | ComputingDevice
+#   | Appliance
+#   | NetworkDevice
+#   | Firewall
+#   | Router
+#   | Switch

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/inventory-item/typeDefs.graphql
@@ -56,6 +56,13 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    "Identifies the name of the inventory item."
+    name: String!
+    "Identifies a description of the Inventory Item, including information about its function."
+    description: String
+    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+    props: [Property]
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -64,10 +71,6 @@
     asset_tag: String
     "Indicates the serial number for the inventory item."
     serial_number: String
-    "Identifies the name of the inventory item."
-    name: String!
-    "Identifies a description of the Inventory Item, including information about its function."
-    description: String
     "Identifies the model of the Inventory Item."
     model: String
     "Identifies the name of the company or organization that manufactured the inventory item"
@@ -100,18 +103,22 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
   # Mutation Types
   input InventoryItemAddInput {
     # Inventory Item
+    "Identifies one or more attributes, characteristics, or qualities of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+    props: [PropertyAddInput]
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType!
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the inventory item."
@@ -156,10 +163,13 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [ID]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsiblePartyAddInput]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [ComponentAddInput]
 }
   # Ordering Types
   enum InventoryItemsOrdering {
@@ -238,6 +248,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -286,12 +297,13 @@
     function: String
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
     "Identifies the identifier for the installation"
     installation_id: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
     "Identifies the set of components that are implemented in a given system inventory item."
     implemented_components: [Component]
   }
@@ -332,6 +344,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType!
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -376,14 +389,15 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
 
 #####   Firewall
@@ -422,6 +436,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -466,16 +481,16 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
 }
-
 #####   Hardware
 ##
   "Defines identifying information about an Hardware"
@@ -512,6 +527,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType!
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -556,14 +572,15 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
 
 #####   Network Device
@@ -602,6 +619,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -646,14 +664,15 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
 
 #####   Router
@@ -692,6 +711,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -736,14 +756,15 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
 
 #####   Switch
@@ -782,6 +803,7 @@
       search: String 
     ): OscalRelationshipConnection
     # Inventory Item
+    # --- props ---
     "Indicates the inventory item's function, such as Router, Storage Array, DNS Server."
     asset_type: AssetType
     "Identifies an organizationally specific identifier that is used to uniquely identify a logical or tangible item by the organization that owns the invenotry item."
@@ -826,14 +848,15 @@
     baseline_configuration_name: String
     "Identifies the function provided by the inventory item for the system."
     function: String
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsibleParty]
     "Indicates the physical location of the inventory item's hardware (e.g., Data Center ID, Cage#, Rack#, or other meaningful location identifiers)."
     physical_location: [OscalLocation]
-    "Identifies the set of components that are implemented in a given system inventory item."
-    implemented_components: [Component]
     "Identifies the CPE identifier for a hardware device"
     cpe_identifier: String
+    # -- end props
+    "Identifies a reference to one or more roles with responsibility for performing a function relative to the containing object."
+    responsible_parties: [OscalResponsibleParty]
+    "Identifies the set of components that are implemented in a given system inventory item."
+    implemented_components: [Component]
   }
 
   union InventoryItemTypes = Hardware 

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscal-common.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscal-common.js
@@ -88,11 +88,11 @@ const oscalCommonResolvers = {
     html: 'text/html',
     pdf: 'application/pdf',
   },
-  PartyOrComponent: {
-    __resolveType: (item) => {
-      return objectMap[item.entity_type].graphQLType;
-    }
-  }
+  // PartyOrComponent: {
+  //   __resolveType: (item) => {
+  //     return objectMap[item.entity_type].graphQLType;
+  //   }
+  // }
 };
 
 export default oscalCommonResolvers;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleRole.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleRole.js
@@ -1,0 +1,490 @@
+import { riskSingularizeSchema as singularizeSchema } from '../../risk-mappings.js';
+import { compareValues, updateQuery, filterValues } from '../../../utils.js';
+import { UserInputError } from "apollo-server-express";
+import {
+  selectLabelByIriQuery,
+  selectExternalReferenceByIriQuery,
+  selectNoteByIriQuery,
+  getReducer as getGlobalReducer,
+} from '../../../global/resolvers/sparql-query.js';
+import {
+  getReducer,
+  insertResponsibleRoleQuery,
+  selectResponsibleRoleQuery,
+  selectAllResponsibleRoles,
+  deleteResponsibleRoleQuery,
+  attachToResponsibleRoleQuery,
+  selectRoleByIriQuery,  
+  responsiblePartyPredicateMap,
+} from './sparql-query.js';
+
+const responsibleRoleResolvers = {
+  Query: {
+    oscalResponsibleRoles: async (_, args, { dbName, dataSources, selectMap }) => {
+      const edges = [];
+      const reducer = getReducer("RESPONSIBLE-ROLE");
+      const sparqlQuery = selectAllResponsibleRoles(selectMap.getNode("node"), args);
+      let response;
+      try {
+        response = await dataSources.Stardog.queryAll({
+          dbName,
+          sparqlQuery,
+          queryId: "Select List of Responsible Roles",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response === undefined) return null;
+
+      // Handle reporting Stardog Error
+      if (typeof (response) === 'object' && 'body' in response) {
+        throw new UserInputError(response.statusText, {
+            error_details: (response.body.message ? response.body.message : response.body),
+            error_code: (response.body.code ? response.body.code : 'N/A')
+        });
+      }
+        
+      let filterCount, resultCount, limit, offset, limitSize, offsetSize;
+      limitSize = limit = (args.first === undefined ? response.length : args.first) ;
+      offsetSize = offset = (args.offset === undefined ? 0 : args.offset) ;
+      filterCount = 0;
+      let respRoleList;
+      if (args.orderedBy !== undefined) {
+        respRoleList = response.sort(compareValues(args.orderedBy, args.orderMode));
+      } else {
+        respRoleList = response;
+      }
+
+      if (offset > respRoleList.length) return null;
+      resultCount = respRoleList.length;
+      for (let respRole of respRoleList) {
+        if (offset) {
+          offset--
+          continue
+        }
+
+        // filter out non-matching entries if a filter is to be applied
+        if ('filters' in args && args.filters != null && args.filters.length > 0) {
+          if (!filterValues(respRole, args.filters, args.filterMode)) {
+            continue
+          }
+          filterCount++;
+        }
+
+        // if haven't reached limit to be returned
+        if (limit) {
+          let edge = {
+            cursor: respRole.iri,
+            node: reducer(respRole),
+          }
+          edges.push(edge)
+          limit--;
+          if (limit === 0) break;
+        }
+      }
+
+      // check if there is data to be returned
+      if (edges.length === 0 ) return null;
+      let hasNextPage = false, hasPreviousPage = false;
+      if (edges.length < resultCount) {
+        if (edges.length === limitSize && filterCount <= limitSize ) {
+          hasNextPage = true;
+          if (offsetSize > 0) hasPreviousPage = true;
+        }
+        if (edges.length <= limitSize) {
+          if (filterCount !== edges.length) hasNextPage = true;
+          if (filterCount > 0 && offsetSize > 0) hasPreviousPage = true;
+        }
+      }
+      return {
+        pageInfo: {
+          startCursor: edges[0].cursor,
+          endCursor: edges[edges.length-1].cursor,
+          hasNextPage: (hasNextPage ),
+          hasPreviousPage: (hasPreviousPage),
+          globalCount: resultCount,
+        },
+        edges: edges,
+      }
+    },
+    oscalResponsibleRole: async (_, { id }, { dbName, dataSources, selectMap }) => {
+      const sparqlQuery = selectResponsibleRoleQuery(id, selectMap.getNode("oscalResponsibleRole"));
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select OSCAL Responsible Party",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+
+      if (response === undefined) return null;
+
+      // Handle reporting Stardog Error
+      if (typeof (response) === 'object' && 'body' in response) {
+        throw new UserInputError(response.statusText, {
+          error_details: (response.body.message ? response.body.message : response.body),
+          error_code: (response.body.code ? response.body.code : 'N/A')
+        });
+      }
+
+      const reducer = getReducer("RESPONSIBLE-ROLE");
+      return reducer(response[0]);
+    }
+  },
+  Mutation: {
+    createOscalResponsibleRole: async (_, { input }, { dbName, selectMap, dataSources }) => {
+      // TODO: WORKAROUND to remove input fields with null or empty values so creation will work
+      for (const [key, value] of Object.entries(input)) {
+        if (Array.isArray(input[key]) && input[key].length === 0) {
+          delete input[key];
+          continue;
+        }
+        if (value === null || value.length === 0) {
+          delete input[key];
+        }
+      }
+      // END WORKAROUND
+
+      // Setup to handle embedded objects to be created
+      let parties, role;
+      if (input.parties !== undefined) {
+        parties = input.parties;
+      }
+      if (input.role !== undefined) {
+        role = input.role;
+      }
+
+      // create the Responsible Party
+      const { id, query } = insertResponsibleRoleQuery(input);
+      await dataSources.Stardog.create({
+        dbName,
+        sparqlQuery: query,
+        queryId: "Create OSCAL Responsible Role"
+      });
+
+      // add the responsible role to the parent object (if supplied)
+
+      // attach associated Role
+      if (role !== undefined && role !== null) {
+        const roleIris = [];
+        roleIris.push(`<http://csrc.nist.gov/ns/oscal/common#Role-${role}>`);
+
+        // attach the Role to the Responsible Role
+        const roleAttachQuery = attachToResponsibleRoleQuery(id, 'role', roleIris);
+        await dataSources.Stardog.create({
+          dbName,
+          sparqlQuery: roleAttachQuery,
+          queryId: "Attach reference to the Role to this Responsible Role"
+        });        
+      }
+      // attach any Parties
+      if (parties !== undefined && parties !== null) {
+        const partyIris = [];
+        for (let partyIri of parties) partyIris.push(`<http://csrc.nist.gov/ns/oscal/common#Party-${partyIri}>`);
+
+        // attach the Party to the Responsible Role
+        const partyAttachQuery = attachToResponsibleRoleQuery(id, 'parties', partyIris);
+        await dataSources.Stardog.create({
+          dbName,
+          sparqlQuery: partyAttachQuery,
+          queryId: "Attach references to one or more Parties to this Responsible Role"
+        });        
+      }
+
+      // retrieve information about the newly created Responsible Role to return to the user
+      const select = selectResponsibleRoleQuery(id, selectMap.getNode("createOscalResponsibleRole"));
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery: select,
+          queryId: "Select OSCAL Responsible Role",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      const reducer = getReducer("RESPONSIBLE-ROLE");
+      return reducer(response[0]);
+    },
+    deleteOscalResponsibleRole: async (_, { id }, { dbName, dataSources }) => {
+      // check that the Role exists
+      const sparqlQuery = selectResponsibleRoleQuery(id, null);
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select OSCAL Responsible Role",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // detach the Responsible Role from the parent object (if supplied)
+
+      // Delete the responsible Role itself
+      const query = deleteResponsibleRoleQuery(id);
+      try {
+        await dataSources.Stardog.delete({
+          dbName,
+          sparqlQuery: query,
+          queryId: "Delete OSCAL Responsible Role"
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      return id;
+    },
+    editOscalResponsibleRole: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+      const sparqlQuery = selectResponsibleRoleQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Responsible Role",
+        singularizeSchema
+      })
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      for (let editItem of input) {
+        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+      }
+      // END WORKAROUND
+
+      const query = updateQuery(
+        `http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}`,
+        "http://csrc.nist.gov/ns/oscal/common#ResponsibleRole",
+        input,
+        responsiblePartyPredicateMap
+      )
+      await dataSources.Stardog.edit({
+        dbName,
+        sparqlQuery: query,
+        queryId: "Update OSCAL Responsible Role"
+      });
+      const select = selectResponsibleRoleQuery(id, selectMap.getNode("editOscalResponsibleRole"));
+      const result = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery: select,
+        queryId: "Select OSCAL Responsible Role",
+        singularizeSchema
+      });
+      const reducer = getReducer("RESPONSIBLE-ROLE");
+      return reducer(result[0]);
+    },
+  },
+  OscalResponsibleRole: {
+    labels: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.labels_iri === undefined) return [];
+      let iriArray = parent.labels_iri;
+      const results = [];
+      if (Array.isArray(iriArray) && iriArray.length > 0) {
+        const reducer = getGlobalReducer("LABEL");
+        for (let iri of iriArray) {
+          if (iri === undefined || !iri.includes('Label')) continue;
+          const sparqlQuery = selectLabelByIriQuery(iri, selectMap.getNode("labels"));
+          let response;
+          try {
+            response = await dataSources.Stardog.queryById({
+              dbName,
+              sparqlQuery,
+              queryId: "Select Label",
+              singularizeSchema
+            });
+          } catch (e) {
+            console.log(e)
+            throw e
+          }
+          if (response === undefined) return [];
+          if (Array.isArray(response) && response.length > 0) {
+            results.push(reducer(response[0]))
+          }
+          else {
+            // Handle reporting Stardog Error
+            if (typeof (response) === 'object' && 'body' in response) {
+              throw new UserInputError(response.statusText, {
+                error_details: (response.body.message ? response.body.message : response.body),
+                error_code: (response.body.code ? response.body.code : 'N/A')
+              });
+            }
+          }  
+        }
+        return results;
+      } else {
+        return [];
+      }
+    },
+    links: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.links_iri === undefined) return [];
+      let iriArray = parent.links_iri;
+      const results = [];
+      if (Array.isArray(iriArray) && iriArray.length > 0) {
+        const reducer = getGlobalReducer("EXTERNAL-REFERENCE");
+        for (let iri of iriArray) {
+          if (iri === undefined || !iri.includes('ExternalReference')) continue;
+          const sparqlQuery = selectExternalReferenceByIriQuery(iri, selectMap.getNode("links"));
+          let response;
+          try {
+            response = await dataSources.Stardog.queryById({
+              dbName,
+              sparqlQuery,
+              queryId: "Select External Reference",
+              singularizeSchema
+            });
+          } catch (e) {
+            console.log(e)
+            throw e
+          }
+          if (response === undefined) return [];
+          if (Array.isArray(response) && response.length > 0) {
+            results.push(reducer(response[0]))
+          }
+          else {
+            // Handle reporting Stardog Error
+            if (typeof (response) === 'object' && 'body' in response) {
+              throw new UserInputError(response.statusText, {
+                error_details: (response.body.message ? response.body.message : response.body),
+                error_code: (response.body.code ? response.body.code : 'N/A')
+              });
+            }
+          }  
+        }
+        return results;
+      } else {
+        return [];
+      }
+    },
+    remarks: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.remarks_iri === undefined) return [];
+      let iriArray = parent.remarks_iri;
+      const results = [];
+      if (Array.isArray(iriArray) && iriArray.length > 0) {
+        const reducer = getGlobalReducer("NOTE");
+        for (let iri of iriArray) {
+          if (iri === undefined || !iri.includes('Note')) continue;
+          const sparqlQuery = selectNoteByIriQuery(iri, selectMap.getNode("remarks"));
+          let response;
+          try {
+            response = await dataSources.Stardog.queryById({
+              dbName,
+              sparqlQuery,
+              queryId: "Select Note",
+              singularizeSchema
+            });
+          } catch (e) {
+            console.log(e)
+            throw e
+          }
+          if (response === undefined) return [];
+          if (Array.isArray(response) && response.length > 0) {
+            results.push(reducer(response[0]))
+          }
+          else {
+            // Handle reporting Stardog Error
+            if (typeof (response) === 'object' && 'body' in response) {
+              throw new UserInputError(response.statusText, {
+                error_details: (response.body.message ? response.body.message : response.body),
+                error_code: (response.body.code ? response.body.code : 'N/A')
+              });
+            }
+          }  
+        }
+        return results;
+      } else {
+        return [];
+      }
+    },
+    parties: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.parties_iri === undefined) return [];
+      let iriArray = parent.parties_iri;
+      const results = [];
+      if (Array.isArray(iriArray) && iriArray.length > 0) {
+        const reducer = getReducer("PARTY");
+        for (let iri of iriArray) {
+          if (iri === undefined || !iri.includes('Party')) continue;
+          const sparqlQuery = selectPartyByIriQuery(iri, selectMap.getNode("parties"));
+          let response;
+          try {
+            response = await dataSources.Stardog.queryById({
+              dbName,
+              sparqlQuery,
+              queryId: "Select Party",
+              singularizeSchema
+            });
+          } catch (e) {
+            console.log(e)
+            throw e
+          }
+          if (response === undefined) return [];
+          if (Array.isArray(response) && response.length > 0) {
+            results.push(reducer(response[0]))
+          }
+          else {
+            // Handle reporting Stardog Error
+            if (typeof (response) === 'object' && 'body' in response) {
+              throw new UserInputError(response.statusText, {
+                error_details: (response.body.message ? response.body.message : response.body),
+                error_code: (response.body.code ? response.body.code : 'N/A')
+              });
+            }
+          }  
+        }
+        return results;
+      } else {
+        return [];
+      }
+    },
+    role: async (parent, _, {dbName, dataSources, selectMap}) => {
+      if (parent.role_iri === undefined) return null;
+      let iri = parent.role_iri[0];
+      const reducer = getReducer("ROLE");
+      const sparqlQuery = selectRoleByIriQuery(iri, selectMap.getNode("role"));
+      let response;
+      try {
+        response = await dataSources.Stardog.queryById({
+          dbName,
+          sparqlQuery,
+          queryId: "Select Role",
+          singularizeSchema
+        });
+      } catch (e) {
+        console.log(e)
+        throw e
+      }
+      if (response === undefined) return null;
+      if (Array.isArray(response) && response.length > 0) {
+        return (reducer(response[0]))
+      }
+      else {
+        // Handle reporting Stardog Error
+        if (typeof (response) === 'object' && 'body' in response) {
+          throw new UserInputError(response.statusText, {
+            error_details: (response.body.message ? response.body.message : response.body),
+            error_code: (response.body.code ? response.body.code : 'N/A')
+          });
+        }
+      }
+      return null;  
+    }
+  }
+}
+
+export default responsibleRoleResolvers;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/sparql-query.js
@@ -73,6 +73,8 @@ export function getReducer(type) {
       return oscalRoleReducer;
     case 'RESPONSIBLE-PARTY':
       return oscalResponsiblePartyReducer;
+    case 'RESPONSIBLE-ROLE':
+      return oscalResponsibleRoleReducer;
     case 'COMPONENT':
       return componentReducer;
     case 'INVENTORY-ITEM':
@@ -162,6 +164,29 @@ export const oscalResponsiblePartyReducer = (item) => {
   // if no object type was returned, compute the type from the IRI
   if ( item.object_type === undefined ) {
     item.object_type = 'oscal-responsible-party';
+  }
+
+  return {
+    iri: item.iri,
+    id: item.id,
+    standard_id: item.id,
+    ...(item.object_type && {entity_type: item.object_type}),
+    ...(item.labels && {labels_iri: item.labels}),
+    ...(item.links && {links_iri: item.links}),
+    ...(item.remarks && {remarks_iri: item.remarks}),
+    ...(item.relationships && {relationship_iri: item.relationships}),
+    // Oscal Responsible Party
+    ...(item.role &&  {role_iri: item.role}),
+    ...(item.parties && {parties_iri: item.parties}),
+    // DarkLight extensions
+    ...(item.name && {name: item.name}),
+    ...(item.description &&  {description: item.description}),
+  }
+}
+export const oscalResponsibleRoleReducer = (item) => {
+  // if no object type was returned, compute the type from the IRI
+  if ( item.object_type === undefined ) {
+    item.object_type = 'oscal-responsible-role';
   }
 
   return {
@@ -831,6 +856,170 @@ export const attachToResponsiblePartyQuery = (id, field, itemIris) => {
 }
 export const detachFromResponsiblePartyQuery = (id, field, itemIris) => {
   const iri = `<http://csrc.nist.gov/ns/oscal/common#ResponsibleParty-${id}>`;
+  if (!responsiblePartyPredicateMap.hasOwnProperty(field)) return null;
+  const predicate = responsiblePartyPredicateMap[field].predicate;
+  let statements;
+  if (Array.isArray(itemIris)) {
+    statements = itemIris
+      .map((itemIri) => `${iri} ${predicate} ${itemIri}`)
+      .join(".\n        ")
+    }
+  else {
+    statements = `${iri} ${predicate} ${itemIris}`;
+  }
+  return `
+  DELETE DATA {
+    GRAPH ${iri} {
+      ${statements}
+    }
+  }
+  `
+}
+
+// Responsible Role support functions
+export const insertResponsibleRoleQuery = (propValues) => {
+  const id_material = {
+    ...(propValues.role && {"role": propValues.role}),
+  } ;
+  const id = generateId( id_material, OSCAL_NS );
+  const iri = `<http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}>`;
+
+  // remove role and parties so predicates don't get generated
+  if ('role' in propValues) delete propValues.role;
+  if ('parties' in propValues) delete propValues.parties;
+
+  const insertPredicates = Object.entries(propValues)
+      .filter((propPair) => responsiblePartyPredicateMap.hasOwnProperty(propPair[0]))
+      .map((propPair) => responsiblePartyPredicateMap[propPair[0]].binding(iri, propPair[1]))
+      .join('. \n      ');
+  const query = `
+  INSERT DATA {
+    GRAPH ${iri} {
+      ${iri} a <http://csrc.nist.gov/ns/oscal/common#ResponsibleRole> .
+      ${iri} a <http://csrc.nist.gov/ns/oscal/common#ComplexDatatype> .
+      ${iri} a <http://darklight.ai/ns/common#ComplexDatatype> .
+      ${iri} <http://darklight.ai/ns/common#id> "${id}".
+      ${iri} <http://darklight.ai/ns/common#object_type> "oscal-responsible-role" . 
+      ${insertPredicates}
+    }
+  }
+  `;
+  return {iri, id, query}
+}
+export const selectResponsibleRoleQuery = (id, select) => {
+  return selectResponsiblePartyByIriQuery(`http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}`, select);
+}
+export const selectResponsibleRoleByIriQuery = (iri, select) => {
+  if (!iri.startsWith('<')) iri = `<${iri}>`;
+  if (select === undefined || select === null) select = Object.keys(responsiblePartyPredicateMap);
+  const { selectionClause, predicates } = buildSelectVariables(responsiblePartyPredicateMap, select);
+  return `
+  SELECT ?iri ${selectionClause}
+  FROM <tag:stardog:api:context:local>
+  WHERE {
+    BIND(${iri} AS ?iri)
+    ?iri a <http://csrc.nist.gov/ns/oscal/common#ResponsibleRole> .
+    ${predicates}
+  }
+  `
+}
+export const selectAllResponsibleRoles = (select, args, parent) => {
+  let constraintClause = '';
+  if (select === undefined || select === null) select = Object.keys(responsiblePartyPredicateMap);
+  if (!select.includes('id')) select.push('id');
+
+  if (args !== undefined ) {
+    if ( args.filters !== undefined ) {
+      for( const filter of args.filters) {
+        if (!select.hasOwnProperty(filter.key)) select.push( filter.key );
+      }
+    }
+    
+    // add value of orderedBy's key to cause special predicates to be included
+    if ( args.orderedBy !== undefined ) {
+      if (!select.hasOwnProperty(args.orderedBy)) select.push(args.orderedBy);
+    }
+  }
+
+  const { selectionClause, predicates } = buildSelectVariables(responsiblePartyPredicateMap, select);
+  // add constraint clause to limit to those that are referenced by the specified POAM
+  if (parent !== undefined && parent.iri !== undefined) {
+    let classTypeIri, predicate;
+    if (parent.entity_type === 'component') {
+      classTypeIri = '<http://csrc.nist.gov/ns/oscal/common#Component>';
+      predicate = '<http://csrc.nist.gov/ns/oscal/common#responsible_roles>';
+    }
+    if (parent.entity_type === 'oscal-task') {
+      classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#Task>';
+      predicate = '<http://csrc.nist.gov/ns/oscal/common#responsible_roles>';
+    }
+    if (parent.entity_type === 'oscal-activity') {
+      classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#Activity>';
+      predicate = '<http://csrc.nist.gov/ns/oscal/common#responsible_roles>';
+    }
+    // define a constraint to limit retrieval to only those referenced by the parent
+    constraintClause = `
+    {
+      SELECT DISTINCT ?iri
+      WHERE {
+          <${parent.iri}> a ${classTypeIri} ;
+            ${predicate} ?iri .
+      }
+    }
+    `;
+  }
+
+  return `
+  SELECT DISTINCT ?iri ${selectionClause} 
+  FROM <tag:stardog:api:context:local>
+  WHERE {
+    ?iri a <http://csrc.nist.gov/ns/oscal/common#ResponsibleRole> . 
+    ${predicates}
+    ${constraintClause}
+  }
+  `
+}
+export const deleteResponsibleRoleQuery = (id) => {
+  const iri = `http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}`;
+  return deleteResponsibleRoleByIriQuery(iri);
+}
+export const deleteResponsibleRoleByIriQuery = (iri) => {
+  return `
+  DELETE {
+    GRAPH <${iri}> {
+      ?iri ?p ?o
+    }
+  } WHERE {
+    GRAPH <${iri}> {
+      ?iri a <http://csrc.nist.gov/ns/oscal/common#ResponsibleRole> .
+      ?iri ?p ?o
+    }
+  }
+  `
+}
+export const attachToResponsibleRoleQuery = (id, field, itemIris) => {
+  const iri = `<http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}>`;
+  if (!responsiblePartyPredicateMap.hasOwnProperty(field)) return null;
+  const predicate = responsiblePartyPredicateMap[field].predicate;
+  let statements;
+  if (Array.isArray(itemIris)) {
+    statements = itemIris
+      .map((itemIri) => `${iri} ${predicate} ${itemIri}`)
+      .join(".\n        ")
+    }
+  else {
+    statements = `${iri} ${predicate} ${itemIris}`;
+  }
+  return `
+  INSERT DATA {
+    GRAPH ${iri} {
+      ${statements}
+    }
+  }
+  `
+}
+export const detachFromResponsibleRoleQuery = (id, field, itemIris) => {
+  const iri = `<http://csrc.nist.gov/ns/oscal/common#ResponsibleRole-${id}>`;
   if (!responsiblePartyPredicateMap.hasOwnProperty(field)) return null;
   const predicate = responsiblePartyPredicateMap[field].predicate;
   let statements;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
@@ -56,6 +56,17 @@
       filterMode: FilterMode
       search: String
     ): OscalResponsiblePartyConnection
+    # OSCAL Responsible Role
+    oscalResponsibleRole(id: ID!): OscalResponsibleRole
+    oscalResponsibleRoles(
+      first: Int
+      offset: Int
+      orderedBy: OscalResponsibleRoleOrdering
+      orderMode: OrderingMode
+      filters: [OscalResponsibleRoleFiltering]
+      filterMode: FilterMode
+      search: String
+    ): OscalResponsibleRoleConnection
     # OSCAL Role
     oscalRole(id: ID!): OscalRole
     oscalRoles(
@@ -110,6 +121,10 @@
     createOscalResponsibleParty(input: OscalResponsiblePartyAddInput): OscalResponsibleParty
     deleteOscalResponsibleParty(id: ID!): String!
     editOscalResponsibleParty( id: ID!, input: [EditInput]!, commitMessage: String): OscalResponsibleParty
+    # OSCAL Responsible Role
+    createOscalResponsibleRole(input: OscalResponsibleRoleAddInput): OscalResponsibleRole
+    deleteOscalResponsibleRole(id: ID!): String!
+    editOscalResponsibleRole( id: ID!, input: [EditInput]!, commitMessage: String): OscalResponsibleRole
     # OSCAL Role
     createOscalRole(input: OscalRoleAddInput): OscalRole
     deleteOscalRole(id: ID!): String!
@@ -128,168 +143,8 @@
       options: [RiskReportOption]): ID
   }
 
-  "Defines the types of OSCAL Models"
-  enum OscalModelType {
-    "OSCAL Assessment Plan"
-    ap
-    "OSCAL Assessment Results"
-    ar
-    "OSCAL Catalog"
-    catalog
-    "OSCAL Component Definition"
-    component_definition
-    "OSCAL Plan of Action and Milestones"
-    poam
-    "OSCAL Profile"
-    profile
-    "OSCAL System Security Plan"
-    ssp
-  }
-
-  "Defines the media types for OSCAL export"
-  enum OscalMediaType {
-    "application/oscal+json"
-    application_oscal_json
-    "application/oscal+xml"
-    application_oscal_xml
-    "application/oscal+yaml"
-    application_oscal_yaml
-    "application/oscal+csv"
-    application_oscal_csv
-  }
-
-  "Defines an risk reporting option"
-  input RiskReportOption {
-    "Identifies the name of the option"
-    name: ReportOptionType!
-    "Identifies the value(s) for the option"
-    values: [String!]
-  }
-
-  "Defines the types of Risk Reports"
-  enum RiskReportType {
-    "Security Assessment Report (SAR)"
-    sar
-    "Vulnerability Assessment Report (VAR)"
-    var
-    "Asset Inventory Report (AIR)"
-    air
-    "Cybersecurity Risk Assessment Report (CRA)"
-    cra
-    "Threat Assessment Report (TAR)"
-    tar
-  } 
-
-  "Defines the Options for Reports"
-  enum ReportOptionType {
-    "Appendices"
-    appendices
-    "Description"
-    description
-    "Purpose"
-    purpose
-    "Max Items"
-    max_items
-    "Sections"
-    sections
-    "Title"
-    title
-  }
-
-  "Defines the media types for Reports"
-  enum ReportMediaType {
-    "text/markdown"
-    markdown
-    "application/pdf"
-    pdf
-    "text/html"
-    html
-  }
-
-## Report-specifics
-  "Defines the sections in a Security Assessment Report"
-  enum SarSections {
-    "Risk Tracking Details"
-    tracking
-    "Collected During Testing"
-    collected_during_testing
-    "Mitigating Factors"
-    mitigating_factor  }
-
-  "Appendices of a Security Assessment Report"
-  enum SarAppendices {
-    "Database Scan"
-    db_scan
-    "Web Scan"
-    web_scan
-    "Penetration Testing"
-    pen_test
-    "Manual Test"
-    manual_test
-  }
-
-
-
-
-  "Defines identifying information about a system privilege held by the user."
-  type AuthorizedPrivilege {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a human readable name for the privilege."
-    name: String!
-    "Identifies a summary of the privilege's purpose within the system."
-    description: String
-    "Identifies one or more functions performed for a given authorized privilege by this user class."
-    functions_performed: [String!]
-  }
-  input AuthorizedPrivilegeAddInput {
-    "Identifies a human readable name for the privilege."
-    name: String!
-    "Identifies a summary of the privilege's purpose within the system."
-    description: String
-    "Identifies one or more functions performed for a given authorized privilege by this user class."
-    functions_performed: [String!]
-  }
-
-  "Defines identifying information about Base64 Content"
-  type Base64Content {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the name of the file before it was encoded as Base64 to be embedded in a resource. This is the name that will be assigned to the file when the file is decoded."
-    filename: String
-    "Identifies the media type as defined by the Internet Assigned Numbers Authority (IANA)."
-    media_type: String
-    "Identifies the content that is base64 encoded."
-    value: String
-  }
-  input Base64ContentAddInput {
-    filename: String
-    media_type: String
-    value: String
-  }
-
-  "Defines identifying information about a citation."
-  type Citation {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a line of citation text."
-    text: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-  }
-  input CitationAddInput {
-    "Identifies a line of citation text."
-    text: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReferenceAddInput]
-  }
-
+##### OSCAL Model
+##
   "Defines identifying information about an OSCAL Model."
   interface Model {
     # BasicObject
@@ -350,6 +205,8 @@
     resources(first: Int, offset: Int): OscalResourceConnection
   }
 
+##### OSCAL Object
+##
   "Defines the identifying information about an OSCAL object."
   interface OscalObject {
     # OscalObject
@@ -371,6 +228,8 @@
     ): OscalRelationshipConnection
   }
 
+##### OSCAL Location
+##
   "Defines identifying information about a location."
   type OscalLocation implements BasicObject & LifecycleObject & OscalObject {
     # BasicObject
@@ -486,7 +345,8 @@
     alternate
   }
 
-
+##### OSCAL Party
+##
   "Defines identifying information about a Party in OSCAL"
   type OscalParty {
     # BasicObject
@@ -628,6 +488,8 @@
     organization
   }
 
+##### OSCAL Relationship
+##
   "Defines identifying information about a relationship in OSCAL"
   type OscalRelationship {
     # BasicObject
@@ -728,7 +590,8 @@
     node: OscalRelationship!
   }
 
-
+##### OSCAL Resource
+##
   "Defines identifying information about a resource in OSCAL"
   type OscalResource implements BasicObject & LifecycleObject & OscalObject {
     # BasicObject
@@ -900,8 +763,45 @@
     "Indicates the resource is a formal agreement between two or more parties"
     agreement
   }
+  "Defines identifying information about Base64 Content"
+  type Base64Content {
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    "Identifies the name of the file before it was encoded as Base64 to be embedded in a resource. This is the name that will be assigned to the file when the file is decoded."
+    filename: String
+    "Identifies the media type as defined by the Internet Assigned Numbers Authority (IANA)."
+    media_type: String
+    "Identifies the content that is base64 encoded."
+    value: String
+  }
+  input Base64ContentAddInput {
+    filename: String
+    media_type: String
+    value: String
+  }
+  "Defines identifying information about a citation."
+  type Citation {
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    "Identifies a line of citation text."
+    text: String!
+    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+    links: [CyioExternalReference]
+  }
+  input CitationAddInput {
+    "Identifies a line of citation text."
+    text: String!
+    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+    links: [CyioExternalReferenceAddInput]
+  }
 
 
+##### OSCAL Responsible Party
+##
   "Defines identifying information about a Responsible Party in OSCAL"
   type OscalResponsibleParty {
     # BasicObject
@@ -943,20 +843,6 @@
     "Identifies a summary of the reponsible party's purpose and associated responsibilities."
     description: String
   }
-
-  "Defines identifying information about a Responsible Role in OSCAL"
-  input OscalResponsibleRoleAddInput {
-    # ResponsibleRole
-    "Identifies a reference to the role that the party is responsible for."
-    role: ID!
-    "Identifies one or more references to the parties that are responsible for performing the associated role."
-    parties: [ID]
-    # DarkLight extensions
-    "Identifies a name given to the responsible role to make it friendlier."
-    name: String
-    "Identifies a summary of the reponsible role's purpose and associated responsibilities."
-    description: String
-  }
   # Ordering
   enum OscalResponsiblePartyOrdering {
     "Label"
@@ -988,7 +874,84 @@
     cursor: String!
     node: OscalResponsibleParty!
   }
+##### OSCAL Responsible Role
+##
+  "Defines identifying information about a role with responsibility for performing a function relative to the containing object."
+  type OscalResponsibleRole {
+    # BasicObject
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the identifier defined by the standard."
+    standard_id: String!
+    "Identifies the type of the Object."
+    entity_type: String!
+    "Identifies the parent types of this object."
+    parent_types: [String]!
+    # OscalObject
+    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+    labels: [CyioLabel]
+    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+    links: [CyioExternalReference]
+    "Identifies one or more references to additional commentary on the Model."
+    remarks: [CyioNote]
+    # ResponsibleParty
+    "Identifies a reference to the role that the party is responsible for."
+    role: OscalRole!
+    "Identifies one or more references to the parties that are responsible for performing the associated role."
+    parties: [OscalParty]
+    # DarkLight extensions
+    "Identifies a name given to the responsible party to make it friendlier."
+    name: String
+    "Identifies a summary of the reponsible party's purpose and associated responsibilities."
+    description: String
+  }
+  "Defines identifying information about a Responsible Role in OSCAL"
+  input OscalResponsibleRoleAddInput {
+    # ResponsibleRole
+    "Identifies a reference to the role that the party is responsible for."
+    role: ID!
+    "Identifies one or more references to the parties that are responsible for performing the associated role."
+    parties: [ID]
+    # DarkLight extensions
+    "Identifies a name given to the responsible role to make it friendlier."
+    name: String
+    "Identifies a summary of the reponsible role's purpose and associated responsibilities."
+    description: String
+  }
+  # Ordering
+  enum OscalResponsibleRoleOrdering {
+    "Label"
+    label_name
+    "Name"
+    name
+  }
+  # Filtering
+  input OscalResponsibleRoleFiltering {
+    key: OscalResponsibleRoleFilter!
+    values: [String]
+    operator: String
+    filterMode: FilterMode
+  }
+  enum OscalResponsibleRoleFilter {
+    "Label"
+    label_name
+    "Role Identifier"
+    role_identifier
+    "Name"
+    name
+  }
+  # Pagination
+  type OscalResponsibleRoleConnection {
+    pageInfo: PageInfo!
+    edges: [OscalResponsibleRoleEdge]
+  }
+  type OscalResponsibleRoleEdge {
+    cursor: String!
+    node: OscalResponsibleRole!
+  }
 
+##### OSCAL Role
+##
   "Defines identifying information about a function assumed or expected to be assumed by a party in a specific situation."
   type OscalRole implements BasicObject & LifecycleObject & OscalObject {
     # BasicObject
@@ -1142,6 +1105,8 @@
   }
 
 
+##### OSCAL User
+##
   "Defines identifying information about a type of user that interacts with the system based on an associated role."
   type OscalUser implements BasicObject & LifecycleObject  & OscalObject {
     # BasicObject
@@ -1270,8 +1235,31 @@
     "This role has no access to the system, such as a manager who approves access as part of a process."
     no_logical_access
   }
+  "Defines identifying information about a system privilege held by the user."
+  type AuthorizedPrivilege {
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    "Identifies a human readable name for the privilege."
+    name: String!
+    "Identifies a summary of the privilege's purpose within the system."
+    description: String
+    "Identifies one or more functions performed for a given authorized privilege by this user class."
+    functions_performed: [String!]
+  }
+  input AuthorizedPrivilegeAddInput {
+    "Identifies a human readable name for the privilege."
+    name: String!
+    "Identifies a summary of the privilege's purpose within the system."
+    description: String
+    "Identifies one or more functions performed for a given authorized privilege by this user class."
+    functions_performed: [String!]
+  }
 
 
+##### OSCAL Revision
+##
   "Defines identifying information about a Revision"
   type Revision {
     "Uniquely identifies this object."
@@ -1314,6 +1302,8 @@
     oscal_version: String
   }
 
+##### OSCAL ExternalIdentifier
+##
   "Defines an external identifier associated with a party"
   type ExternalIdentifier {
     "Uniquely identifies this object."
@@ -1331,4 +1321,136 @@
     "Identifies the external identifier within a specified scheme."
     identifier: String!
   }
-  
+##### Risk Reports
+##
+  "Defines the types of OSCAL Models"
+  enum OscalModelType {
+    "OSCAL Assessment Plan"
+    ap
+    "OSCAL Assessment Results"
+    ar
+    "OSCAL Catalog"
+    catalog
+    "OSCAL Component Definition"
+    component_definition
+    "OSCAL Plan of Action and Milestones"
+    poam
+    "OSCAL Profile"
+    profile
+    "OSCAL System Security Plan"
+    ssp
+  }
+
+  "Defines the media types for OSCAL export"
+  enum OscalMediaType {
+    "application/oscal+json"
+    application_oscal_json
+    "application/oscal+xml"
+    application_oscal_xml
+    "application/oscal+yaml"
+    application_oscal_yaml
+    "application/oscal+csv"
+    application_oscal_csv
+  }
+
+  "Defines an risk reporting option"
+  input RiskReportOption {
+    "Identifies the name of the option"
+    name: ReportOptionType!
+    "Identifies the value(s) for the option"
+    values: [String!]
+  }
+
+  "Defines the types of Risk Reports"
+  enum RiskReportType {
+    "Security Assessment Report (SAR)"
+    sar
+    "Vulnerability Assessment Report (VAR)"
+    var
+    "Asset Inventory Report (AIR)"
+    air
+    "Cybersecurity Risk Assessment Report (CRA)"
+    cra
+    "Threat Assessment Report (TAR)"
+    tar
+  } 
+
+  "Defines the Options for Reports"
+  enum ReportOptionType {
+    "Appendices"
+    appendices
+    "Description"
+    description
+    "Purpose"
+    purpose
+    "Max Items"
+    max_items
+    "Sections"
+    sections
+    "Title"
+    title
+  }
+
+  "Defines the media types for Reports"
+  enum ReportMediaType {
+    "text/markdown"
+    markdown
+    "application/pdf"
+    pdf
+    "text/html"
+    html
+  }
+
+##### SAR Report-Specifics
+##
+  "Defines the sections in a Security Assessment Report"
+  enum SarSections {
+    "Risk Tracking Details"
+    tracking
+    "Collected During Testing"
+    collected_during_testing
+    "Mitigating Factors"
+    mitigating_factor  }
+
+  "Appendices of a Security Assessment Report"
+  enum SarAppendices {
+    "Database Scan"
+    db_scan
+    "Web Scan"
+    web_scan
+    "Penetration Testing"
+    pen_test
+    "Manual Test"
+    manual_test
+  }
+
+##### OSCAL Property
+##
+  "Defines an attribute, characteristic, or quality of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+  type Property implements ComplexDatatype {
+    # ComplexDatatype
+    "Uniquely identifies this object."
+    id: ID!
+    "Identifies the type of the Object."
+    entity_type: String!
+    # OSCAL Property
+    "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
+    prop_name: String!
+    "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
+    ns: URL
+    "Indicates the value of the attribute, characteristic, or quality."
+    value: [String!]
+    "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
+    class: String
+  }
+    input PropertyAddInput {
+    # OSCAL Property
+    "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
+    prop_name: String!
+    "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
+    ns: URL
+    "Indicates the value of the attribute, characteristic, or quality."
+    value: [String!]
+    "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
+    class: String
+  }

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/typeDefs.graphql
@@ -1,1456 +1,1505 @@
-  # contains common type definitions used across OSCAL objects
-  # declares the query entry-points for this type
-  extend type Query {
-    # OSCAL Location
-    oscalLocation(id: ID!): OscalLocation
-    oscalLocations(
-      first: Int
-      offset: Int
-      orderedBy: OscalLocationOrdering
-      orderMode: OrderingMode
-      filters: [OscalLocationFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalLocationConnection
-    # OSCAL Party
-    oscalParty(id: ID!): OscalParty
-    oscalParties(
-      first: Int
-      offset: Int
-      orderedBy: OscalPartyOrdering
-      orderMode: OrderingMode
-      filters: [OscalPartyFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalPartyConnection
-    # OSCAL Relationship
-    oscalRelationship(id: ID!): OscalRelationship
-    oscalRelationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalRelationshipConnection
-    # OSCAL Resource
-    oscalResource(id: ID!): OscalResource
-    oscalResources(
-      first: Int
-      offset: Int
-      orderedBy: OscalResourcesOrdering
-      orderMode: OrderingMode
-      filters: [OscalResourcesFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalResourceConnection
-    # OSCAL Responsible Party
-    oscalResponsibleParty(id: ID!): OscalResponsibleParty
-    oscalResponsibleParties(
-      first: Int
-      offset: Int
-      orderedBy: OscalResponsiblePartyOrdering
-      orderMode: OrderingMode
-      filters: [OscalResponsiblePartyFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalResponsiblePartyConnection
-    # OSCAL Responsible Role
-    oscalResponsibleRole(id: ID!): OscalResponsibleRole
-    oscalResponsibleRoles(
-      first: Int
-      offset: Int
-      orderedBy: OscalResponsibleRoleOrdering
-      orderMode: OrderingMode
-      filters: [OscalResponsibleRoleFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalResponsibleRoleConnection
-    # OSCAL Role
-    oscalRole(id: ID!): OscalRole
-    oscalRoles(
-      first: Int
-      offset: Int
-      orderedBy: OscalRolesOrdering
-      orderMode: OrderingMode
-      filters: [OscalRolesFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalRoleConnection
-    # OSCAL User
-    oscalUser(id: ID!): OscalUser
-    oscalUsers(
-      first: Int
-      offset: Int
-      orderedBy: OscalUsersOrdering
-      orderMode: OrderingMode
-      filters: [OscalUsersFiltering]
-      filterMode: FilterMode
-      search: String
-    ): OscalUserConnection
-  }
+# contains common type definitions used across OSCAL objects
+# declares the query entry-points for this type
+extend type Query {
+  # OSCAL Location
+  oscalLocation(id: ID!): OscalLocation
+  oscalLocations(
+    first: Int
+    offset: Int
+    orderedBy: OscalLocationOrdering
+    orderMode: OrderingMode
+    filters: [OscalLocationFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalLocationConnection
+  # OSCAL Party
+  oscalParty(id: ID!): OscalParty
+  oscalParties(
+    first: Int
+    offset: Int
+    orderedBy: OscalPartyOrdering
+    orderMode: OrderingMode
+    filters: [OscalPartyFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalPartyConnection
+  # OSCAL Relationship
+  oscalRelationship(id: ID!): OscalRelationship
+  oscalRelationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+  # OSCAL Resource
+  oscalResource(id: ID!): OscalResource
+  oscalResources(
+    first: Int
+    offset: Int
+    orderedBy: OscalResourcesOrdering
+    orderMode: OrderingMode
+    filters: [OscalResourcesFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalResourceConnection
+  # OSCAL Responsible Party
+  oscalResponsibleParty(id: ID!): OscalResponsibleParty
+  oscalResponsibleParties(
+    first: Int
+    offset: Int
+    orderedBy: OscalResponsiblePartyOrdering
+    orderMode: OrderingMode
+    filters: [OscalResponsiblePartyFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalResponsiblePartyConnection
+  # OSCAL Responsible Role
+  oscalResponsibleRole(id: ID!): OscalResponsibleRole
+  oscalResponsibleRoles(
+    first: Int
+    offset: Int
+    orderedBy: OscalResponsibleRoleOrdering
+    orderMode: OrderingMode
+    filters: [OscalResponsibleRoleFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalResponsibleRoleConnection
+  # OSCAL Role
+  oscalRole(id: ID!): OscalRole
+  oscalRoles(
+    first: Int
+    offset: Int
+    orderedBy: OscalRolesOrdering
+    orderMode: OrderingMode
+    filters: [OscalRolesFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRoleConnection
+  # OSCAL User
+  oscalUser(id: ID!): OscalUser
+  oscalUsers(
+    first: Int
+    offset: Int
+    orderedBy: OscalUsersOrdering
+    orderMode: OrderingMode
+    filters: [OscalUsersFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalUserConnection
+}
 
-  # declares the mutation entry-points for this type
-  extend type Mutation {
-    # Base64Content
-    createBase64Content(input: Base64ContentAddInput): Base64Content
-    deleteBase64Content(id: ID!): String!
-    editBase64Content( id: ID!, input: [EditInput]!, commitMessage: String): Base64Content
-    # Citation
-    createCitation(input: CitationAddInput): Citation
-    deleteCitation(id: ID!): String!
-    editCitation( id: ID!, input: [EditInput]!, commitMessage: String): Citation
-    # OSCAL Location
-    createOscalLocation(input: OscalLocationAddInput): OscalLocation
-    deleteOscalLocation(id: ID!): String!
-    editOscalLocation( id: ID!, input: [EditInput]!, commitMessage: String): OscalLocation
-    # OSCAL Party
-    createOscalParty(input: OscalPartyAddInput): OscalParty
-    deleteOscalParty(id: ID!): String!
-    editOscalParty( id: ID!, input: [EditInput]!, commitMessage: String): OscalParty
-    # OSCAL Relationship
-    createOscalRelationship(input: OscalRelationshipAddInput): OscalRelationship
-    deleteOscalRelationship(id: ID!): String!
-    editOscalRelationship( id: ID!, input: [EditInput]!, commitMessage: String): OscalRelationship
-    # OSCAL Resource
-    createOscalResource(input: OscalResourceAddInput): OscalResource
-    deleteOscalResource(id: ID!): String!
-    editOscalResource( id: ID!, input: [EditInput]!, commitMessage: String): OscalResource
-    # OSCAL Responsible Party
-    createOscalResponsibleParty(input: OscalResponsiblePartyAddInput): OscalResponsibleParty
-    deleteOscalResponsibleParty(id: ID!): String!
-    editOscalResponsibleParty( id: ID!, input: [EditInput]!, commitMessage: String): OscalResponsibleParty
-    # OSCAL Responsible Role
-    createOscalResponsibleRole(input: OscalResponsibleRoleAddInput): OscalResponsibleRole
-    deleteOscalResponsibleRole(id: ID!): String!
-    editOscalResponsibleRole( id: ID!, input: [EditInput]!, commitMessage: String): OscalResponsibleRole
-    # OSCAL Role
-    createOscalRole(input: OscalRoleAddInput): OscalRole
-    deleteOscalRole(id: ID!): String!
-    editOscalRole( id: ID!, input: [EditInput]!, commitMessage: String): OscalRole
-    # OSCAL User
-    createOscalUser(input: OscalUserAddInput): OscalUser
-    deleteOscalUser(id: ID!): String!
-    editOscalUser( id: ID!, input: [EditInput]!, commitMessage: String): OscalUser
-    # Export OSCAL Model
-    exportOscal(model: OscalModelType, id: ID, media_type: OscalMediaType): ID
-    # Generate Report
-    generateRiskReport( 
-      report: RiskReportType!, 
-      id: ID, 
-      media_type: ReportMediaType, 
-      options: [RiskReportOption]): ID
-  }
+# declares the mutation entry-points for this type
+extend type Mutation {
+  # Base64Content
+  createBase64Content(input: Base64ContentAddInput): Base64Content
+  deleteBase64Content(id: ID!): String!
+  editBase64Content(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): Base64Content
+  # Citation
+  createCitation(input: CitationAddInput): Citation
+  deleteCitation(id: ID!): String!
+  editCitation(id: ID!, input: [EditInput]!, commitMessage: String): Citation
+  # OSCAL Location
+  createOscalLocation(input: OscalLocationAddInput): OscalLocation
+  deleteOscalLocation(id: ID!): String!
+  editOscalLocation(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalLocation
+  # OSCAL Party
+  createOscalParty(input: OscalPartyAddInput): OscalParty
+  deleteOscalParty(id: ID!): String!
+  editOscalParty(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalParty
+  # OSCAL Relationship
+  createOscalRelationship(input: OscalRelationshipAddInput): OscalRelationship
+  deleteOscalRelationship(id: ID!): String!
+  editOscalRelationship(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalRelationship
+  # OSCAL Resource
+  createOscalResource(input: OscalResourceAddInput): OscalResource
+  deleteOscalResource(id: ID!): String!
+  editOscalResource(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalResource
+  # OSCAL Responsible Party
+  createOscalResponsibleParty(
+    input: OscalResponsiblePartyAddInput
+  ): OscalResponsibleParty
+  deleteOscalResponsibleParty(id: ID!): String!
+  editOscalResponsibleParty(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalResponsibleParty
+  # OSCAL Responsible Role
+  createOscalResponsibleRole(
+    input: OscalResponsibleRoleAddInput
+  ): OscalResponsibleRole
+  deleteOscalResponsibleRole(id: ID!): String!
+  editOscalResponsibleRole(
+    id: ID!
+    input: [EditInput]!
+    commitMessage: String
+  ): OscalResponsibleRole
+  # OSCAL Role
+  createOscalRole(input: OscalRoleAddInput): OscalRole
+  deleteOscalRole(id: ID!): String!
+  editOscalRole(id: ID!, input: [EditInput]!, commitMessage: String): OscalRole
+  # OSCAL User
+  createOscalUser(input: OscalUserAddInput): OscalUser
+  deleteOscalUser(id: ID!): String!
+  editOscalUser(id: ID!, input: [EditInput]!, commitMessage: String): OscalUser
+  # Export OSCAL Model
+  exportOscal(model: OscalModelType, id: ID, media_type: OscalMediaType): ID
+  # Generate Report
+  generateRiskReport(
+    report: RiskReportType!
+    id: ID
+    media_type: ReportMediaType
+    options: [RiskReportOption]
+  ): ID
+}
 
 ##### OSCAL Model
 ##
-  "Defines identifying information about an OSCAL Model."
-  interface Model {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # LifecycleObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Metadata
-    "Identifies the name given to the document."
-    name: String!
-    "Identifies the date and time the document was published."
-    published: Timestamp
-    "Identifies the date and time the document as last modified."
-    last_modified: Timestamp
-    "Identifies the current version of the document."
-    version: String!
-    "Identifies the OSCAL model version the document was authored against."
-    oscal_version: String!
-    "Identifies a list of revisions to the containing document."
-    revisions: [Revision]
-    "Identifies references to previous versions of this document."
-    document_ids: [ID]
-    "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
-    roles(first: Int, offset: Int): OscalRoleConnection
-    "Identifies one or more references to a location."
-    locations(first: Int, offset: Int): OscalLocationConnection
-    "Identifies one or more references to a responsible entity which is either a person or an organization."
-    parties(first: Int, offset: Int): OscalPartyConnection
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties(first: Int, offset: Int): OscalResponsiblePartyConnection
-    # Back-matter
-    resources(first: Int, offset: Int): OscalResourceConnection
-  }
+"Defines identifying information about an OSCAL Model."
+interface Model {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # LifecycleObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+  # Metadata
+  "Identifies the name given to the document."
+  name: String!
+  "Identifies the date and time the document was published."
+  published: Timestamp
+  "Identifies the date and time the document as last modified."
+  last_modified: Timestamp
+  "Identifies the current version of the document."
+  version: String!
+  "Identifies the OSCAL model version the document was authored against."
+  oscal_version: String!
+  "Identifies a list of revisions to the containing document."
+  revisions: [Revision]
+  "Identifies references to previous versions of this document."
+  document_ids: [ID]
+  "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
+  roles(first: Int, offset: Int): OscalRoleConnection
+  "Identifies one or more references to a location."
+  locations(first: Int, offset: Int): OscalLocationConnection
+  "Identifies one or more references to a responsible entity which is either a person or an organization."
+  parties(first: Int, offset: Int): OscalPartyConnection
+  "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
+  responsible_parties(first: Int, offset: Int): OscalResponsiblePartyConnection
+  # Back-matter
+  resources(first: Int, offset: Int): OscalResourceConnection
+}
 
 ##### OSCAL Object
 ##
-  "Defines the identifying information about an OSCAL object."
-  interface OscalObject {
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-  }
+"Defines the identifying information about an OSCAL object."
+interface OscalObject {
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+}
 
 ##### OSCAL Location
 ##
-  "Defines identifying information about a location."
-  type OscalLocation implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # LifecycleObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # CyioLocation
-    "Identifies the name given to the location."
-    name: String!
-    "Identifies a brief description of the location."
-    description: String
-    # Oscal Location
-    "Identifies the type of the location."
-    location_type: OscalLocationType
-    "Identifies the purpose of the location."
-    location_class: OscalLocationClass
-    "Identifies a postal addresses for the location."
-    address: CivicAddress
-    "Identifies one or more email addresses for the location."
-    email_addresses: [EmailAddress]
-    "Identifies one or more telephone numbers used to contact the the location."
-    telephone_numbers: [TelephoneNumber]
-    "Identifies one or more uniform resource locator (URL) for a web site or Internet presence associated with the location."
-    urls: [URL]
-  }
-  input OscalLocationAddInput {
-    # CyioLocation
-    name: String!
-    description: String
-    # OscalLocation
-    location_type: OscalLocationType
-    location_class: OscalLocationClass
-    address: CivicAddressAddInput
-    email_addresses: [EmailAddress]
-    telephone_numbers: [TelephoneNumberAddInput]
-    urls: [URL]
-  }
-  # Ordering
-  enum OscalLocationOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Filtering Types
-  enum OscalLocationFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  input OscalLocationFiltering {
-    key: OscalLocationFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a location."
+type OscalLocation implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # LifecycleObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  # Pagination Types
-  type OscalLocationConnection {
-    pageInfo: PageInfo!
-    edges: [OscalLocationEdge]
-    }
-  type OscalLocationEdge {
-    cursor: String!
-    node: OscalLocation!
-  }
-  # Object-specific Enumerations
-  "Characterizes the kind of location."
-  enum OscalLocationType {
-    "A location that contains computing assets."
-    data_center
-  }
-  "Characterizes the purpose of the location."
-  enum OscalLocationClass {
-    "The location is a data-center used for normal operations."
-    primary
-    "The location is a data-center used for fail-over or backup operations."
-    alternate
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # CyioLocation
+  "Identifies the name given to the location."
+  name: String!
+  "Identifies a brief description of the location."
+  description: String
+  # Oscal Location
+  "Identifies the type of the location."
+  location_type: OscalLocationType
+  "Identifies the purpose of the location."
+  location_class: OscalLocationClass
+  "Identifies a postal addresses for the location."
+  address: CivicAddress
+  "Identifies one or more email addresses for the location."
+  email_addresses: [EmailAddress]
+  "Identifies one or more telephone numbers used to contact the the location."
+  telephone_numbers: [TelephoneNumber]
+  "Identifies one or more uniform resource locator (URL) for a web site or Internet presence associated with the location."
+  urls: [URL]
+}
+input OscalLocationAddInput {
+  # CyioLocation
+  name: String!
+  description: String
+  # OscalLocation
+  location_type: OscalLocationType
+  location_class: OscalLocationClass
+  address: CivicAddressAddInput
+  email_addresses: [EmailAddress]
+  telephone_numbers: [TelephoneNumberAddInput]
+  urls: [URL]
+}
+# Ordering
+enum OscalLocationOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Marking"
+  marking
+}
+# Filtering Types
+enum OscalLocationFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+}
+input OscalLocationFiltering {
+  key: OscalLocationFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+# Pagination Types
+type OscalLocationConnection {
+  pageInfo: PageInfo!
+  edges: [OscalLocationEdge]
+}
+type OscalLocationEdge {
+  cursor: String!
+  node: OscalLocation!
+}
+# Object-specific Enumerations
+"Characterizes the kind of location."
+enum OscalLocationType {
+  "A location that contains computing assets."
+  data_center
+}
+"Characterizes the purpose of the location."
+enum OscalLocationClass {
+  "The location is a data-center used for normal operations."
+  primary
+  "The location is a data-center used for fail-over or backup operations."
+  alternate
+}
 
 ##### OSCAL Party
 ##
-  "Defines identifying information about a Party in OSCAL"
-  type OscalParty {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # LifecycleObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # CyioIdentity
-    "Identifies the name given to the party."
-    name: String!
-    "Identifies a brief description of the Party."
-    description: String
-    # OscalParty
-    "Identifies the kind of party the object describes."
-    party_type: PartyType!
-    "Identifies a short common name, abbreviation, or acronym for the party."
-    short_name: String
-    "Identifies one or more external identifiers for a person or organization using a designated scheme. e.g. an Open Researcher and Contributor ID (ORCID)."
-    external_identifiers: [ExternalIdentifier]
-    "Identifies a postal addresses for the location."
-    addresses: [CivicAddress]
-    "Identifies one or more email addresses for the location."
-    email_addresses: [EmailAddress]
-    "Identifies one or more telephone numbers used to contact the the location."
-    telephone_numbers: [TelephoneNumber]
-    "Identifies one or more references to a location."
-    locations: [OscalLocation]
-    "Identifies a mail stop associated with the party."
-    mail_stop: String
-    "Identifies the  name or number of the party's office."
-    office: String
-    "Identifies that the party object is a member of this organization."
-    member_of_organizations: [OscalParty]
-    "Identifes the formal job title of this person"
-    job_title: String
-  }
-  input OscalPartyAddInput {
-    # OscalParty
-    "Identifies the kind of party the object describes."
-    party_type: PartyType!
-    "Identifies the name given to the party."
-    name: String!
-    "Identifies a short common name, abbreviation, or acronym for the party."
-    short_name: String
-    "Identifies a brief description of the Party."
-    description: String
-    "Identifies one or more external identifiers for a person or organization using a designated scheme. e.g. an Open Researcher and Contributor ID (ORCID)."
-    external_identifiers: [ExternalIdentifierAddInput]
-    "Identifies one or more email addresses for the location."
-    email_addresses: [EmailAddress]
-    "Identifies one or more telephone numbers used to contact the the location."
-    telephone_numbers: [TelephoneNumberAddInput]
-    "Identifies a postal addresses for the location."
-    addresses: [CivicAddressAddInput]
-    "Identifies one or more references to a location."
-    locations: [ID]
-    "Identifies a mail stop associated with the party."
-    mail_stop: String
-    "Identifies the  name or number of the party's office."
-    office: String
-    "Identifies that the party object is a member of the organization."
-    member_of_organizations: [ID]
-    "Identifes the formal job title of this person"
-    job_title: String
-  }
-  # Ordering Type
-  enum OscalPartyOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Party Type"
-    party_type
-  }
-  # Filtering Types
-  enum OscalPartyFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Party Type"
-    party_type
-  }
-  input OscalPartyFiltering {
-    key: OscalPartyFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a Party in OSCAL"
+type OscalParty {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # LifecycleObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  # Pagination Types
-  type OscalPartyConnection {
-    pageInfo: PageInfo!
-    edges: [OscalPartyEdge]
-  }
-  type OscalPartyEdge {
-    cursor: String!
-    node: OscalParty!
-  }
-  # Object-specific Enumerations
-  "Characterizes the type of the party."
-  enum PartyType {
-    "Indicates the party is a person"
-    person
-    "Indicates the party is an organization"
-    organization
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # CyioIdentity
+  "Identifies the name given to the party."
+  name: String!
+  "Identifies a brief description of the Party."
+  description: String
+  # OscalParty
+  "Identifies the kind of party the object describes."
+  party_type: PartyType!
+  "Identifies a short common name, abbreviation, or acronym for the party."
+  short_name: String
+  "Identifies one or more external identifiers for a person or organization using a designated scheme. e.g. an Open Researcher and Contributor ID (ORCID)."
+  external_identifiers: [ExternalIdentifier]
+  "Identifies a postal addresses for the location."
+  addresses: [CivicAddress]
+  "Identifies one or more email addresses for the location."
+  email_addresses: [EmailAddress]
+  "Identifies one or more telephone numbers used to contact the the location."
+  telephone_numbers: [TelephoneNumber]
+  "Identifies one or more references to a location."
+  locations: [OscalLocation]
+  "Identifies a mail stop associated with the party."
+  mail_stop: String
+  "Identifies the  name or number of the party's office."
+  office: String
+  "Identifies that the party object is a member of this organization."
+  member_of_organizations: [OscalParty]
+  "Identifes the formal job title of this person"
+  job_title: String
+}
+input OscalPartyAddInput {
+  # OscalParty
+  "Identifies the kind of party the object describes."
+  party_type: PartyType!
+  "Identifies the name given to the party."
+  name: String!
+  "Identifies a short common name, abbreviation, or acronym for the party."
+  short_name: String
+  "Identifies a brief description of the Party."
+  description: String
+  "Identifies one or more external identifiers for a person or organization using a designated scheme. e.g. an Open Researcher and Contributor ID (ORCID)."
+  external_identifiers: [ExternalIdentifierAddInput]
+  "Identifies one or more email addresses for the location."
+  email_addresses: [EmailAddress]
+  "Identifies one or more telephone numbers used to contact the the location."
+  telephone_numbers: [TelephoneNumberAddInput]
+  "Identifies a postal addresses for the location."
+  addresses: [CivicAddressAddInput]
+  "Identifies one or more references to a location."
+  locations: [ID]
+  "Identifies a mail stop associated with the party."
+  mail_stop: String
+  "Identifies the  name or number of the party's office."
+  office: String
+  "Identifies that the party object is a member of the organization."
+  member_of_organizations: [ID]
+  "Identifes the formal job title of this person"
+  job_title: String
+}
+# Ordering Type
+enum OscalPartyOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Party Type"
+  party_type
+  "Marking"
+  marking
+}
+# Filtering Types
+enum OscalPartyFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Party Type"
+  party_type
+}
+input OscalPartyFiltering {
+  key: OscalPartyFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+# Pagination Types
+type OscalPartyConnection {
+  pageInfo: PageInfo!
+  edges: [OscalPartyEdge]
+}
+type OscalPartyEdge {
+  cursor: String!
+  node: OscalParty!
+}
+# Object-specific Enumerations
+"Characterizes the type of the party."
+enum PartyType {
+  "Indicates the party is a person"
+  person
+  "Indicates the party is an organization"
+  organization
+}
 
 ##### OSCAL Relationship
 ##
-  "Defines identifying information about a relationship in OSCAL"
-  type OscalRelationship {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    # OscalRelationship
-    "Identifies the type of the relationship"
-    relationship_type: String!
-    "Identifies a human-readable description about the relationship"
-    description: String
-    "Identifies the source of the relationship"
-    source: ID
-    "Identifies the target of the relationship"
-    target: ID
-    "Indicates the time and date when the relationship was first established"
-    valid_from: Timestamp
-    "Indicates the time and date when the relationship was terminated."
-    valid_until: Timestamp
-    "Identifies the level of confidence in the assertion."
-    confidence: PositiveInt
-  }
-  input OscalRelationshipAddInput {
-    # OscalRelationship
-    "Identifies the type of the relationship"
-    relationship_type: String!
-    "Identifies a human-readable description about the relationship"
-    description: String
-    "Identifies the source of the relationship"
-    source: ID
-    "Identifies the target of the relationship"
-    target: ID
-    "Indicates the time and date when the relationship was first established"
-    valid_from: Timestamp
-    "Indicates the time and date when the relationship was terminated."
-    valid_until: Timestamp
-    "Identifies the level of confidence in the assertion."
-    confidence: PositiveInt
-  }
-  # Ordering
-  enum OscalRelationshipsOrdering {
-    "Relationship Type"
-    relationship_type
-    "Created"
-    created
-    "Modified"
-    modified
-    "Confidence"
-    confidence
-    "Valid From"
-    valid_from
-    "Valid To"
-    valid_until
-  }
-  # Filtering
-  input OscalRelationshipsFiltering {
-    key: OscalRelationshipsFilter!
-    values: [String]
-    operator: String
-    filterMode: FilterMode
-  }
-  enum OscalRelationshipsFilter {
-    "Source"
-    source
-    "Target"
-    target
-    "Created"
-    created
-    "Modified"
-    modified
-    "Confidence"
-    confidence
-  }
-  # Pagination
-  type OscalRelationshipConnection {
-    pageInfo: PageInfo!
-    edges: [OscalRelationshipEdge]
-  }
-  type OscalRelationshipEdge {
-    cursor: String!
-    node: OscalRelationship!
-  }
+"Defines identifying information about a relationship in OSCAL"
+type OscalRelationship {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  # OscalRelationship
+  "Identifies the type of the relationship"
+  relationship_type: String!
+  "Identifies a human-readable description about the relationship"
+  description: String
+  "Identifies the source of the relationship"
+  source: ID
+  "Identifies the target of the relationship"
+  target: ID
+  "Indicates the time and date when the relationship was first established"
+  valid_from: Timestamp
+  "Indicates the time and date when the relationship was terminated."
+  valid_until: Timestamp
+  "Identifies the level of confidence in the assertion."
+  confidence: PositiveInt
+}
+input OscalRelationshipAddInput {
+  # OscalRelationship
+  "Identifies the type of the relationship"
+  relationship_type: String!
+  "Identifies a human-readable description about the relationship"
+  description: String
+  "Identifies the source of the relationship"
+  source: ID
+  "Identifies the target of the relationship"
+  target: ID
+  "Indicates the time and date when the relationship was first established"
+  valid_from: Timestamp
+  "Indicates the time and date when the relationship was terminated."
+  valid_until: Timestamp
+  "Identifies the level of confidence in the assertion."
+  confidence: PositiveInt
+}
+# Ordering
+enum OscalRelationshipsOrdering {
+  "Relationship Type"
+  relationship_type
+  "Created"
+  created
+  "Modified"
+  modified
+  "Confidence"
+  confidence
+  "Valid From"
+  valid_from
+  "Valid To"
+  valid_until
+}
+# Filtering
+input OscalRelationshipsFiltering {
+  key: OscalRelationshipsFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalRelationshipsFilter {
+  "Source"
+  source
+  "Target"
+  target
+  "Created"
+  created
+  "Modified"
+  modified
+  "Confidence"
+  confidence
+}
+# Pagination
+type OscalRelationshipConnection {
+  pageInfo: PageInfo!
+  edges: [OscalRelationshipEdge]
+}
+type OscalRelationshipEdge {
+  cursor: String!
+  node: OscalRelationship!
+}
 
 ##### OSCAL Resource
 ##
-  "Defines identifying information about a resource in OSCAL"
-  type OscalResource implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Resource
-    "Identifies the type of resource represented."
-    resource_type: ResourceType!
-    "Identifies the version number of a published document."
-    version: String
-    "Identifies the publication date of a published document."
-    published: Timestamp
-    "Identifies the name given to the party."
-    name: String!
-    "Identifies a brief description of the Party."
-    description: String
-    "Identifies references to previous versions of this document."
-    document_ids: [OscalObject]
-    "Identifies a citation consisting of end note text and optional structured bibliographic data."
-    citations: [Citation]
-    "identifies one or more references to an external resource with an optional hash for verification and change detection."
-    rlinks: [CyioExternalReference]
-    "Identifies the base64 encoded content."
-    base64: Base64Content
-  }
-  input OscalResourceAddInput {
-    # Resource
-    "Identifies the type of resource represented."
-    resource_type: ResourceType!
-    "Identifies the version number of a published document."
-    version: String
-    "Identifies the publication date of a published document."
-    published: Timestamp
-    "Identifies the name given to the party."
-    name: String!
-    "Identifies a brief description of the Party."
-    description: String
-    "Identifies references to previous versions of this document."
-    document_ids: [ID]
-    "Identifies a citation consisting of end note text and optional structured bibliographic data."
-    citations: [CitationAddInput]
-    "Identifies the base64 encoded content."
-    base64: Base64ContentAddInput
-  }
-  # Ordering
-  enum OscalResourcesOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Published"
-    published
-    "Resource Type"
-    resource_type
-    "Version"
-    version
-  }
-  # Filtering
-  input OscalResourcesFiltering {
-    key: OscalResourcesFilter!
-    values: [String]
-    operator: String
+"Defines identifying information about a resource in OSCAL"
+type OscalResource implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum OscalResourcesFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Resource Type"
-    resource_type
-    "Name"
-    name
-    "Published"
-    published
-  }
-  # Pagination
-  type OscalResourceConnection {
-    pageInfo: PageInfo!
-    edges: [OscalResourceEdge]
-  }
-  type OscalResourceEdge {
-    cursor: String!
-    node: OscalResource!
-  }
-  # Object-specific Enumerations
-  "Characterizes the type of resource."
-  enum ResourceType {
-    "Indicates the resource is an organization's logo."
-    logo
-    "Indicates the resource represents an image."
-    image
-    "Indicates the resource represents an image of screen content."
-    screen_shot
-    "Indicates the resource represents an applicable law."
-    law
-    "Indicates the resource represents an applicable regulation."
-    regulation
-    "Indicates the resource represents an applicable standard."
-    standard
-    "Indicates the resource represents applicable guidance."
-    external_guidance
-    "Indicates the resource provides a list of relevant acronyms"
-    acronyms
-    "Indicates the resource cites relevant information"
-    citation
-    "Indicates the resource is a policy"
-    policy
-    "Indicates the resource is a procedure"
-    procedure
-    "Indicates the resource is guidance document related to the subject system of an SSP."
-    system_guide
-    "Indicates the resource is guidance document a user's guide or administrator's guide."
-    users_guide
-    "Indicates the resource is guidance document a administrator's guide."
-    administrators_guide
-    "Indicates the resource represents rules of behavior content"
-    rules_of_behavior
-    "Indicates the resource represents a plan"
-    plan
-    "Indicates the resource represents an artifact, such as may be reviewed by an assessor"
-    artifact
-    "Indicates the resource represents evidence, such as to support an assessment finding"
-    evidence
-    "Indicates the resource represents output from a tool"
-    tool_output
-    "Indicates the resource represents machine data, which may require a tool or analysis for interpretation or presentation"
-    raw_data
-    "Indicates the resource represents notes from an interview, such as may be collected during an assessment"
-    interview_notes
-    "Indicates the resource is a set of questions, possibly with responses"
-    questionnaire
-    "Indicates the resource is a report"
-    report
-    "Indicates the resource is a formal agreement between two or more parties"
-    agreement
-  }
-  "Defines identifying information about Base64 Content"
-  type Base64Content {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the name of the file before it was encoded as Base64 to be embedded in a resource. This is the name that will be assigned to the file when the file is decoded."
-    filename: String
-    "Identifies the media type as defined by the Internet Assigned Numbers Authority (IANA)."
-    media_type: String
-    "Identifies the content that is base64 encoded."
-    value: String
-  }
-  input Base64ContentAddInput {
-    filename: String
-    media_type: String
-    value: String
-  }
-  "Defines identifying information about a citation."
-  type Citation {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a line of citation text."
-    text: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-  }
-  input CitationAddInput {
-    "Identifies a line of citation text."
-    text: String!
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReferenceAddInput]
-  }
-
+    search: String
+  ): OscalRelationshipConnection
+  # Resource
+  "Identifies the type of resource represented."
+  resource_type: ResourceType!
+  "Identifies the version number of a published document."
+  version: String
+  "Identifies the publication date of a published document."
+  published: Timestamp
+  "Identifies the name given to the party."
+  name: String!
+  "Identifies a brief description of the Party."
+  description: String
+  "Identifies references to previous versions of this document."
+  document_ids: [OscalObject]
+  "Identifies a citation consisting of end note text and optional structured bibliographic data."
+  citations: [Citation]
+  "identifies one or more references to an external resource with an optional hash for verification and change detection."
+  rlinks: [CyioExternalReference]
+  "Identifies the base64 encoded content."
+  base64: Base64Content
+}
+input OscalResourceAddInput {
+  # Resource
+  "Identifies the type of resource represented."
+  resource_type: ResourceType!
+  "Identifies the version number of a published document."
+  version: String
+  "Identifies the publication date of a published document."
+  published: Timestamp
+  "Identifies the name given to the party."
+  name: String!
+  "Identifies a brief description of the Party."
+  description: String
+  "Identifies references to previous versions of this document."
+  document_ids: [ID]
+  "Identifies a citation consisting of end note text and optional structured bibliographic data."
+  citations: [CitationAddInput]
+  "Identifies the base64 encoded content."
+  base64: Base64ContentAddInput
+}
+# Ordering
+enum OscalResourcesOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Published"
+  published
+  "Resource Type"
+  resource_type
+  "Version"
+  version
+  "Marking"
+  marking
+}
+# Filtering
+input OscalResourcesFiltering {
+  key: OscalResourcesFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalResourcesFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Resource Type"
+  resource_type
+  "Name"
+  name
+  "Published"
+  published
+}
+# Pagination
+type OscalResourceConnection {
+  pageInfo: PageInfo!
+  edges: [OscalResourceEdge]
+}
+type OscalResourceEdge {
+  cursor: String!
+  node: OscalResource!
+}
+# Object-specific Enumerations
+"Characterizes the type of resource."
+enum ResourceType {
+  "Indicates the resource is an organization's logo."
+  logo
+  "Indicates the resource represents an image."
+  image
+  "Indicates the resource represents an image of screen content."
+  screen_shot
+  "Indicates the resource represents an applicable law."
+  law
+  "Indicates the resource represents an applicable regulation."
+  regulation
+  "Indicates the resource represents an applicable standard."
+  standard
+  "Indicates the resource represents applicable guidance."
+  external_guidance
+  "Indicates the resource provides a list of relevant acronyms"
+  acronyms
+  "Indicates the resource cites relevant information"
+  citation
+  "Indicates the resource is a policy"
+  policy
+  "Indicates the resource is a procedure"
+  procedure
+  "Indicates the resource is guidance document related to the subject system of an SSP."
+  system_guide
+  "Indicates the resource is guidance document a user's guide or administrator's guide."
+  users_guide
+  "Indicates the resource is guidance document a administrator's guide."
+  administrators_guide
+  "Indicates the resource represents rules of behavior content"
+  rules_of_behavior
+  "Indicates the resource represents a plan"
+  plan
+  "Indicates the resource represents an artifact, such as may be reviewed by an assessor"
+  artifact
+  "Indicates the resource represents evidence, such as to support an assessment finding"
+  evidence
+  "Indicates the resource represents output from a tool"
+  tool_output
+  "Indicates the resource represents machine data, which may require a tool or analysis for interpretation or presentation"
+  raw_data
+  "Indicates the resource represents notes from an interview, such as may be collected during an assessment"
+  interview_notes
+  "Indicates the resource is a set of questions, possibly with responses"
+  questionnaire
+  "Indicates the resource is a report"
+  report
+  "Indicates the resource is a formal agreement between two or more parties"
+  agreement
+}
+"Defines identifying information about Base64 Content"
+type Base64Content {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the name of the file before it was encoded as Base64 to be embedded in a resource. This is the name that will be assigned to the file when the file is decoded."
+  filename: String
+  "Identifies the media type as defined by the Internet Assigned Numbers Authority (IANA)."
+  media_type: String
+  "Identifies the content that is base64 encoded."
+  value: String
+}
+input Base64ContentAddInput {
+  filename: String
+  media_type: String
+  value: String
+}
+"Defines identifying information about a citation."
+type Citation {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies a line of citation text."
+  text: String!
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+}
+input CitationAddInput {
+  "Identifies a line of citation text."
+  text: String!
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReferenceAddInput]
+}
 
 ##### OSCAL Responsible Party
 ##
-  "Defines identifying information about a Responsible Party in OSCAL"
-  type OscalResponsibleParty {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    # ResponsibleParty
-    "Identifies a reference to the role that the party is responsible for."
-    role: OscalRole!
-    "Identifies one or more references to the parties that are responsible for performing the associated role."
-    parties: [OscalParty!]!
-    # DarkLight extensions
-    "Identifies a name given to the responsible party to make it friendlier."
-    name: String
-    "Identifies a summary of the reponsible party's purpose and associated responsibilities."
-    description: String
-  }
-  input OscalResponsiblePartyAddInput {
-    # ResponsibleParty
-    "Identifies a reference to the role that the party is responsible for."
-    role: ID!
-    "Identifies one or more references to the parties that are responsible for performing the associated role."
-    parties: [ID!]!
-    # DarkLight extensions
-    "Identifies a name given to the responsible party to make it friendlier."
-    name: String
-    "Identifies a summary of the reponsible party's purpose and associated responsibilities."
-    description: String
-  }
-  # Ordering
-  enum OscalResponsiblePartyOrdering {
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Filtering
-  input OscalResponsiblePartyFiltering {
-    key: OscalResponsiblePartyFilter!
-    values: [String]
-    operator: String
-    filterMode: FilterMode
-  }
-  enum OscalResponsiblePartyFilter {
-    "Label"
-    label_name
-    "Role Identifier"
-    role_identifier
-    "Name"
-    name
-  }
-  # Pagination
-  type OscalResponsiblePartyConnection {
-    pageInfo: PageInfo!
-    edges: [OscalResponsiblePartyEdge]
-  }
-  type OscalResponsiblePartyEdge {
-    cursor: String!
-    node: OscalResponsibleParty!
-  }
+"Defines identifying information about a Responsible Party in OSCAL"
+type OscalResponsibleParty {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  # ResponsibleParty
+  "Identifies a reference to the role that the party is responsible for."
+  role: OscalRole!
+  "Identifies one or more references to the parties that are responsible for performing the associated role."
+  parties: [OscalParty!]!
+  # DarkLight extensions
+  "Identifies a name given to the responsible party to make it friendlier."
+  name: String
+  "Identifies a summary of the reponsible party's purpose and associated responsibilities."
+  description: String
+}
+input OscalResponsiblePartyAddInput {
+  # ResponsibleParty
+  "Identifies a reference to the role that the party is responsible for."
+  role: ID!
+  "Identifies one or more references to the parties that are responsible for performing the associated role."
+  parties: [ID!]!
+  # DarkLight extensions
+  "Identifies a name given to the responsible party to make it friendlier."
+  name: String
+  "Identifies a summary of the reponsible party's purpose and associated responsibilities."
+  description: String
+}
+# Ordering
+enum OscalResponsiblePartyOrdering {
+  "Label"
+  label_name
+  "Name"
+  name
+  "Role Identifier"
+  role_identifier
+  "Marking"
+  marking
+}
+# Filtering
+input OscalResponsiblePartyFiltering {
+  key: OscalResponsiblePartyFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalResponsiblePartyFilter {
+  "Label"
+  label_name
+  "Role Identifier"
+  role_identifier
+  "Name"
+  name
+}
+# Pagination
+type OscalResponsiblePartyConnection {
+  pageInfo: PageInfo!
+  edges: [OscalResponsiblePartyEdge]
+}
+type OscalResponsiblePartyEdge {
+  cursor: String!
+  node: OscalResponsibleParty!
+}
 ##### OSCAL Responsible Role
 ##
-  "Defines identifying information about a role with responsibility for performing a function relative to the containing object."
-  type OscalResponsibleRole {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    # ResponsibleParty
-    "Identifies a reference to the role that the party is responsible for."
-    role: OscalRole!
-    "Identifies one or more references to the parties that are responsible for performing the associated role."
-    parties: [OscalParty]
-    # DarkLight extensions
-    "Identifies a name given to the responsible party to make it friendlier."
-    name: String
-    "Identifies a summary of the reponsible party's purpose and associated responsibilities."
-    description: String
-  }
-  "Defines identifying information about a Responsible Role in OSCAL"
-  input OscalResponsibleRoleAddInput {
-    # ResponsibleRole
-    "Identifies a reference to the role that the party is responsible for."
-    role: ID!
-    "Identifies one or more references to the parties that are responsible for performing the associated role."
-    parties: [ID]
-    # DarkLight extensions
-    "Identifies a name given to the responsible role to make it friendlier."
-    name: String
-    "Identifies a summary of the reponsible role's purpose and associated responsibilities."
-    description: String
-  }
-  # Ordering
-  enum OscalResponsibleRoleOrdering {
-    "Label"
-    label_name
-    "Name"
-    name
-  }
-  # Filtering
-  input OscalResponsibleRoleFiltering {
-    key: OscalResponsibleRoleFilter!
-    values: [String]
-    operator: String
-    filterMode: FilterMode
-  }
-  enum OscalResponsibleRoleFilter {
-    "Label"
-    label_name
-    "Role Identifier"
-    role_identifier
-    "Name"
-    name
-  }
-  # Pagination
-  type OscalResponsibleRoleConnection {
-    pageInfo: PageInfo!
-    edges: [OscalResponsibleRoleEdge]
-  }
-  type OscalResponsibleRoleEdge {
-    cursor: String!
-    node: OscalResponsibleRole!
-  }
+"Defines identifying information about a role with responsibility for performing a function relative to the containing object."
+type OscalResponsibleRole {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  # ResponsibleParty
+  "Identifies a reference to the role that the party is responsible for."
+  role: OscalRole!
+  "Identifies one or more references to the parties that are responsible for performing the associated role."
+  parties: [OscalParty]
+  # DarkLight extensions
+  "Identifies a name given to the responsible party to make it friendlier."
+  name: String
+  "Identifies a summary of the reponsible party's purpose and associated responsibilities."
+  description: String
+}
+"Defines identifying information about a Responsible Role in OSCAL"
+input OscalResponsibleRoleAddInput {
+  # ResponsibleRole
+  "Identifies a reference to the role that the party is responsible for."
+  role: ID!
+  "Identifies one or more references to the parties that are responsible for performing the associated role."
+  parties: [ID]
+  # DarkLight extensions
+  "Identifies a name given to the responsible role to make it friendlier."
+  name: String
+  "Identifies a summary of the reponsible role's purpose and associated responsibilities."
+  description: String
+}
+# Ordering
+enum OscalResponsibleRoleOrdering {
+  "Label"
+  label_name
+  "Name"
+  name
+  "Role Identifier"
+  role_identifier
+  "Marking"
+  marking
+}
+# Filtering
+input OscalResponsibleRoleFiltering {
+  key: OscalResponsibleRoleFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalResponsibleRoleFilter {
+  "Label"
+  label_name
+  "Role Identifier"
+  role_identifier
+  "Name"
+  name
+}
+# Pagination
+type OscalResponsibleRoleConnection {
+  pageInfo: PageInfo!
+  edges: [OscalResponsibleRoleEdge]
+}
+type OscalResponsibleRoleEdge {
+  cursor: String!
+  node: OscalResponsibleRole!
+}
 
 ##### OSCAL Role
 ##
-  "Defines identifying information about a function assumed or expected to be assumed by a party in a specific situation."
-  type OscalRole implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # OscalRole
-    "Identifies the unique identifier for a specific role instance."
-    role_identifier: RoleType!
-    "Identifies the name given to the role."
-    name: String!
-    "Identifies a short common name, abbreviation, or acronym for the role."
-    short_name: String
-    "Identifies a summary of the role's purpose and associated responsibilities."
-    description: String
-  }
-  input OscalRoleAddInput {
-    # OscalRole
-    "Identifies the unique identifier for a specific role instance."
-    role_identifier: RoleType!
-    "Identifies the name given to the role."
-    name: String!
-    "Identifies a short common name, abbreviation, or acronym for the role."
-    short_name: String
-    "Identifies a summary of the role's purpose and associated responsibilities."
-    description: String
-  }
-  # Ordering
-  enum OscalRolesOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Role"
-    role_identifier
-  }
-  # Filtering
-  input OscalRolesFiltering {
-    key: OscalRolesFilter!
-    values: [String]
-    operator: String
+"Defines identifying information about a function assumed or expected to be assumed by a party in a specific situation."
+type OscalRole implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum OscalRolesFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Role"
-    role_identifier
-  }
-  # Pagination
-  type OscalRoleConnection {
-    pageInfo: PageInfo!
-    edges: [OscalRoleEdge]
-  }
-  type OscalRoleEdge {
-    cursor: String!
-    node: OscalRole!
-  }
-  # Object-specific Enumerations
-  "Defines the identifier for a specific role."
-  enum RoleType {
-    "Responsible for administering a set of assets."
-    asset_administrator
-    "Accountable for ensuring the asset is managed in accordance with organizational policies and procedures."
-    asset_owner
-    "The authorizing official for this system."
-    authorizing_official
-    "The authorizing official's designated point of contact (POC) for this system."
-    authorizing_official_poc
-    "Responsible for the configuration management processes governing changes to the asset."
-    configuration_management
-    "Indicates the organization to contact for questions or support related to this content."
-    contact
-    "Indicates the organization responsible for all content represented in the 'document'."
-    content_approver
-    "Indicates the organization that created this content."
-    creator
-    "Responsible for providing information and support to users."
-    help_desk
-    "Responsible for responding to an event that could lead to loss of, or disruption to, an organization's operations, services or functions."
-    incident_response
-    "The primary role responsible for ensuring the organization operates the system securely."
-    information_system_security_officer
-    "Interconnection Security Agreement (ISA) authorizing official for this system."
-    isa_authorizing_official_local
-    "Interconnection Security Agreement (ISA) authorizing official for the remote interconnected system."
-    isa_authorizing_official_remote
-    "Interconnection Security Agreement (ISA) point of contact (POC) for this system."
-    isa_poc_local
-    "Interconnection Security Agreement (ISA) point of contact (POC) for the remote interconnected system."
-    isa_poc_remote
-    "Responsible for the creation and maintenance of a component."
-    maintainer
-    "Member of the network operations center (NOC)."
-    network_operations
-    "Indicates the organization that prepared this content."
-    prepared_by
-    "Indicates the organization for which this content was created."
-    prepared_for
-    "The point of contact (POC) responsible for identifying privacy information within the system, and ensuring its protection if present."
-    privacy_poc
-    "Organization responsible for providing the component, if this is different from the 'maintainer' (e.g., a reseller)."
-    provider
-    "Member of the security operations center (SOC)."
-    security_operations
-    "The executive ultimately accountable for the system."
-    system_owner
-    "The primary management-level point of contact (POC) for the system."
-    system_poc_management
-    "Other point of contact (POC) for the system that is not the management or technical POC."
-    system_poc_other
-    "The primary technical point of contact (POC) for the system."
-    system_poc_technical
-  }
-
+    search: String
+  ): OscalRelationshipConnection
+  # OscalRole
+  "Identifies the unique identifier for a specific role instance."
+  role_identifier: RoleType!
+  "Identifies the name given to the role."
+  name: String!
+  "Identifies a short common name, abbreviation, or acronym for the role."
+  short_name: String
+  "Identifies a summary of the role's purpose and associated responsibilities."
+  description: String
+}
+input OscalRoleAddInput {
+  # OscalRole
+  "Identifies the unique identifier for a specific role instance."
+  role_identifier: RoleType!
+  "Identifies the name given to the role."
+  name: String!
+  "Identifies a short common name, abbreviation, or acronym for the role."
+  short_name: String
+  "Identifies a summary of the role's purpose and associated responsibilities."
+  description: String
+}
+# Ordering
+enum OscalRolesOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Role"
+  role_identifier
+  "Marking"
+  marking
+}
+# Filtering
+input OscalRolesFiltering {
+  key: OscalRolesFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalRolesFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Role"
+  role_identifier
+}
+# Pagination
+type OscalRoleConnection {
+  pageInfo: PageInfo!
+  edges: [OscalRoleEdge]
+}
+type OscalRoleEdge {
+  cursor: String!
+  node: OscalRole!
+}
+# Object-specific Enumerations
+"Defines the identifier for a specific role."
+enum RoleType {
+  "Responsible for administering a set of assets."
+  asset_administrator
+  "Accountable for ensuring the asset is managed in accordance with organizational policies and procedures."
+  asset_owner
+  "The authorizing official for this system."
+  authorizing_official
+  "The authorizing official's designated point of contact (POC) for this system."
+  authorizing_official_poc
+  "Responsible for the configuration management processes governing changes to the asset."
+  configuration_management
+  "Indicates the organization to contact for questions or support related to this content."
+  contact
+  "Indicates the organization responsible for all content represented in the 'document'."
+  content_approver
+  "Indicates the organization that created this content."
+  creator
+  "Responsible for providing information and support to users."
+  help_desk
+  "Responsible for responding to an event that could lead to loss of, or disruption to, an organization's operations, services or functions."
+  incident_response
+  "The primary role responsible for ensuring the organization operates the system securely."
+  information_system_security_officer
+  "Interconnection Security Agreement (ISA) authorizing official for this system."
+  isa_authorizing_official_local
+  "Interconnection Security Agreement (ISA) authorizing official for the remote interconnected system."
+  isa_authorizing_official_remote
+  "Interconnection Security Agreement (ISA) point of contact (POC) for this system."
+  isa_poc_local
+  "Interconnection Security Agreement (ISA) point of contact (POC) for the remote interconnected system."
+  isa_poc_remote
+  "Responsible for the creation and maintenance of a component."
+  maintainer
+  "Member of the network operations center (NOC)."
+  network_operations
+  "Indicates the organization that prepared this content."
+  prepared_by
+  "Indicates the organization for which this content was created."
+  prepared_for
+  "The point of contact (POC) responsible for identifying privacy information within the system, and ensuring its protection if present."
+  privacy_poc
+  "Organization responsible for providing the component, if this is different from the 'maintainer' (e.g., a reseller)."
+  provider
+  "Member of the security operations center (SOC)."
+  security_operations
+  "The executive ultimately accountable for the system."
+  system_owner
+  "The primary management-level point of contact (POC) for the system."
+  system_poc_management
+  "Other point of contact (POC) for the system that is not the management or technical POC."
+  system_poc_other
+  "The primary technical point of contact (POC) for the system."
+  system_poc_technical
+}
 
 ##### OSCAL User
 ##
-  "Defines identifying information about a type of user that interacts with the system based on an associated role."
-  type OscalUser implements BasicObject & LifecycleObject  & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    # OscalObject
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # OSCAL SystemAsset User
-    "Identifies type of user, such as internal, external, or general-public."
-    user_type: UserType
-    "Identifies a name given to the user, which may be used by a tool for display and navigation."
-    name: String!
-    "Identifies a short common name, abbreviation, or acronym for the user."
-    short_name: String
-    "Identifies a summary of the user's purpose within the system."
-    description: String
-    "Identifies one or more references to the roles served by the user."
-    roles: [OscalRole]
-    "Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege."
-    authorized_privileges: [AuthorizedPrivilege!]
-    "Identifies the user's privilege level within the system, such as privileged, non-privileged, no-logical-access."
-    privilege_level: PrivilegeLevel!
-  }
-  input OscalUserAddInput {
-    # OSCAL User
-    "Identifies type of user, such as internal, external, or general-public."
-    user_type: UserType
-    "Identifies a name given to the user, which may be used by a tool for display and navigation."
-    name: String!
-    "Identifies a short common name, abbreviation, or acronym for the user."
-    short_name: String
-    "Identifies a summary of the user's purpose within the system."
-    description: String
-    "Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege."
-    authorized_privileges: [AuthorizedPrivilegeAddInput]
-    "Identifies the user's privilege level within the system, such as privileged, non-privileged, no-logical-access."
-    privilege_level: PrivilegeLevel!
-  }
-  # Ordering
-  enum OscalUsersOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Prvilege Level"
-    privilege_level
-    "User Type"
-    user_type
-  }
-  # Filtering
-  input OscalUsersFiltering {
-    key: OscalUsersFilter!
-    values: [String]
-    operator: String
+"Defines identifying information about a type of user that interacts with the system based on an associated role."
+type OscalUser implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  # OscalObject
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
-  enum OscalUsersFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "Name"
-    name
-    "Privilege Level"
-    privilege_level
-    "User Type"
-    user_type
-  }
-  # Pagination
-  type OscalUserConnection {
-    pageInfo: PageInfo!
-    edges: [OscalUserEdge]
-  }
-  type OscalUserEdge {
-    cursor: String!
-    node: OscalUser!
-  }
-  # Object-specific Enumerations
-  "Defines the set of types of users"
-  enum UserType {
-    "Identifies a user account for a person or entity that is part of the organization who owns or operates the system."
-    internal
-    "Identifies a user account for a person or entity that is not part of the organization who owns or operates the system."
-    external
-    "Identifies a user of the system considered to be outside."
-    general_public
-  }
-  "Characterizes the type level of privileges"
-  enum PrivilegeLevel {
-    "This role has elevated access to the system, such as a group or system administrator."
-    privileged
-    "This role has typical user-level access to the system without elevated access."
-    non_privileged
-    "This role has no access to the system, such as a manager who approves access as part of a process."
-    no_logical_access
-  }
-  "Defines identifying information about a system privilege held by the user."
-  type AuthorizedPrivilege {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies a human readable name for the privilege."
-    name: String!
-    "Identifies a summary of the privilege's purpose within the system."
-    description: String
-    "Identifies one or more functions performed for a given authorized privilege by this user class."
-    functions_performed: [String!]
-  }
-  input AuthorizedPrivilegeAddInput {
-    "Identifies a human readable name for the privilege."
-    name: String!
-    "Identifies a summary of the privilege's purpose within the system."
-    description: String
-    "Identifies one or more functions performed for a given authorized privilege by this user class."
-    functions_performed: [String!]
-  }
-
+    search: String
+  ): OscalRelationshipConnection
+  # OSCAL SystemAsset User
+  "Identifies type of user, such as internal, external, or general-public."
+  user_type: UserType
+  "Identifies a name given to the user, which may be used by a tool for display and navigation."
+  name: String!
+  "Identifies a short common name, abbreviation, or acronym for the user."
+  short_name: String
+  "Identifies a summary of the user's purpose within the system."
+  description: String
+  "Identifies one or more references to the roles served by the user."
+  roles: [OscalRole]
+  "Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege."
+  authorized_privileges: [AuthorizedPrivilege!]
+  "Identifies the user's privilege level within the system, such as privileged, non-privileged, no-logical-access."
+  privilege_level: PrivilegeLevel!
+}
+input OscalUserAddInput {
+  # OSCAL User
+  "Identifies type of user, such as internal, external, or general-public."
+  user_type: UserType
+  "Identifies a name given to the user, which may be used by a tool for display and navigation."
+  name: String!
+  "Identifies a short common name, abbreviation, or acronym for the user."
+  short_name: String
+  "Identifies a summary of the user's purpose within the system."
+  description: String
+  "Identifies a specific system privilege held by the user, along with an associated description and/or rationale for the privilege."
+  authorized_privileges: [AuthorizedPrivilegeAddInput]
+  "Identifies the user's privilege level within the system, such as privileged, non-privileged, no-logical-access."
+  privilege_level: PrivilegeLevel!
+}
+# Ordering
+enum OscalUsersOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Prvilege Level"
+  privilege_level
+  "User Type"
+  user_type
+  "Marking"
+  marking
+}
+# Filtering
+input OscalUsersFiltering {
+  key: OscalUsersFilter!
+  values: [String]
+  operator: String
+  filterMode: FilterMode
+}
+enum OscalUsersFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "Name"
+  name
+  "Privilege Level"
+  privilege_level
+  "User Type"
+  user_type
+}
+# Pagination
+type OscalUserConnection {
+  pageInfo: PageInfo!
+  edges: [OscalUserEdge]
+}
+type OscalUserEdge {
+  cursor: String!
+  node: OscalUser!
+}
+# Object-specific Enumerations
+"Defines the set of types of users"
+enum UserType {
+  "Identifies a user account for a person or entity that is part of the organization who owns or operates the system."
+  internal
+  "Identifies a user account for a person or entity that is not part of the organization who owns or operates the system."
+  external
+  "Identifies a user of the system considered to be outside."
+  general_public
+}
+"Characterizes the type level of privileges"
+enum PrivilegeLevel {
+  "This role has elevated access to the system, such as a group or system administrator."
+  privileged
+  "This role has typical user-level access to the system without elevated access."
+  non_privileged
+  "This role has no access to the system, such as a manager who approves access as part of a process."
+  no_logical_access
+}
+"Defines identifying information about a system privilege held by the user."
+type AuthorizedPrivilege {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies a human readable name for the privilege."
+  name: String!
+  "Identifies a summary of the privilege's purpose within the system."
+  description: String
+  "Identifies one or more functions performed for a given authorized privilege by this user class."
+  functions_performed: [String!]
+}
+input AuthorizedPrivilegeAddInput {
+  "Identifies a human readable name for the privilege."
+  name: String!
+  "Identifies a summary of the privilege's purpose within the system."
+  description: String
+  "Identifies one or more functions performed for a given authorized privilege by this user class."
+  functions_performed: [String!]
+}
 
 ##### OSCAL Revision
 ##
-  "Defines identifying information about a Revision"
-  type Revision {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the name given to the document."
-    name: String!
-    "Identifies the date and time the document was published."
-    published: Timestamp
-    "Identifies the date and time the document as last modified."
-    last_modified: Timestamp
-    "Identifies the current version of the document."
-    version: String
-    "Identifies the OSCAL model version the document was authored against."
-    oscal_version: String
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-  }
-  input RevisionAddInput {
-    "Identifies the name given to the document."
-    name: String!
-    "Identifies the date and time the document was published."
-    published: Timestamp
-    "Identifies the date and time the document as last modified."
-    last_modified: Timestamp
-    "Identifies the current version of the document."
-    version: String
-    "Identifies the OSCAL model version the document was authored against."
-    oscal_version: String
-  }
+"Defines identifying information about a Revision"
+type Revision {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the name given to the document."
+  name: String!
+  "Identifies the date and time the document was published."
+  published: Timestamp
+  "Identifies the date and time the document as last modified."
+  last_modified: Timestamp
+  "Identifies the current version of the document."
+  version: String
+  "Identifies the OSCAL model version the document was authored against."
+  oscal_version: String
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): OscalRelationshipConnection
+}
+input RevisionAddInput {
+  "Identifies the name given to the document."
+  name: String!
+  "Identifies the date and time the document was published."
+  published: Timestamp
+  "Identifies the date and time the document as last modified."
+  last_modified: Timestamp
+  "Identifies the current version of the document."
+  version: String
+  "Identifies the OSCAL model version the document was authored against."
+  oscal_version: String
+}
 
 ##### OSCAL ExternalIdentifier
 ##
-  "Defines an external identifier associated with a party"
-  type ExternalIdentifier {
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the type or scheme of the external identifier"
-    scheme: URL!
-    "Identifies the external identifier"
-    identifier: String!
-  }
-  input ExternalIdentifierAddInput {
-    "Identifies the type or scheme of an external identifier as a URI."
-    scheme: URL!
-    "Identifies the external identifier within a specified scheme."
-    identifier: String!
-  }
+"Defines an external identifier associated with a party"
+type ExternalIdentifier {
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the type or scheme of the external identifier"
+  scheme: URL!
+  "Identifies the external identifier"
+  identifier: String!
+}
+input ExternalIdentifierAddInput {
+  "Identifies the type or scheme of an external identifier as a URI."
+  scheme: URL!
+  "Identifies the external identifier within a specified scheme."
+  identifier: String!
+}
 ##### Risk Reports
 ##
-  "Defines the types of OSCAL Models"
-  enum OscalModelType {
-    "OSCAL Assessment Plan"
-    ap
-    "OSCAL Assessment Results"
-    ar
-    "OSCAL Catalog"
-    catalog
-    "OSCAL Component Definition"
-    component_definition
-    "OSCAL Plan of Action and Milestones"
-    poam
-    "OSCAL Profile"
-    profile
-    "OSCAL System Security Plan"
-    ssp
-  }
+"Defines the types of OSCAL Models"
+enum OscalModelType {
+  "OSCAL Assessment Plan"
+  ap
+  "OSCAL Assessment Results"
+  ar
+  "OSCAL Catalog"
+  catalog
+  "OSCAL Component Definition"
+  component_definition
+  "OSCAL Plan of Action and Milestones"
+  poam
+  "OSCAL Profile"
+  profile
+  "OSCAL System Security Plan"
+  ssp
+}
 
-  "Defines the media types for OSCAL export"
-  enum OscalMediaType {
-    "application/oscal+json"
-    application_oscal_json
-    "application/oscal+xml"
-    application_oscal_xml
-    "application/oscal+yaml"
-    application_oscal_yaml
-    "application/oscal+csv"
-    application_oscal_csv
-  }
+"Defines the media types for OSCAL export"
+enum OscalMediaType {
+  "application/oscal+json"
+  application_oscal_json
+  "application/oscal+xml"
+  application_oscal_xml
+  "application/oscal+yaml"
+  application_oscal_yaml
+  "application/oscal+csv"
+  application_oscal_csv
+}
 
-  "Defines an risk reporting option"
-  input RiskReportOption {
-    "Identifies the name of the option"
-    name: ReportOptionType!
-    "Identifies the value(s) for the option"
-    values: [String!]
-  }
+"Defines an risk reporting option"
+input RiskReportOption {
+  "Identifies the name of the option"
+  name: ReportOptionType!
+  "Identifies the value(s) for the option"
+  values: [String!]
+}
 
-  "Defines the types of Risk Reports"
-  enum RiskReportType {
-    "Security Assessment Report (SAR)"
-    sar
-    "Vulnerability Assessment Report (VAR)"
-    var
-    "Asset Inventory Report (AIR)"
-    air
-    "Cybersecurity Risk Assessment Report (CRA)"
-    cra
-    "Threat Assessment Report (TAR)"
-    tar
-  } 
+"Defines the types of Risk Reports"
+enum RiskReportType {
+  "Security Assessment Report (SAR)"
+  sar
+  "Vulnerability Assessment Report (VAR)"
+  var
+  "Asset Inventory Report (AIR)"
+  air
+  "Cybersecurity Risk Assessment Report (CRA)"
+  cra
+  "Threat Assessment Report (TAR)"
+  tar
+}
 
-  "Defines the Options for Reports"
-  enum ReportOptionType {
-    "Appendices"
-    appendices
-    "Description"
-    description
-    "Purpose"
-    purpose
-    "Max Items"
-    max_items
-    "Sections"
-    sections
-    "Title"
-    title
-  }
+"Defines the Options for Reports"
+enum ReportOptionType {
+  "Appendices"
+  appendices
+  "Description"
+  description
+  "Purpose"
+  purpose
+  "Max Items"
+  max_items
+  "Sections"
+  sections
+  "Title"
+  title
+}
 
-  "Defines the media types for Reports"
-  enum ReportMediaType {
-    "text/markdown"
-    markdown
-    "application/pdf"
-    pdf
-    "text/html"
-    html
-  }
+"Defines the media types for Reports"
+enum ReportMediaType {
+  "text/markdown"
+  markdown
+  "application/pdf"
+  pdf
+  "text/html"
+  html
+}
 
 ##### SAR Report-Specifics
 ##
-  "Defines the sections in a Security Assessment Report"
-  enum SarSections {
-    "Risk Tracking Details"
-    tracking
-    "Collected During Testing"
-    collected_during_testing
-    "Mitigating Factors"
-    mitigating_factor  }
+"Defines the sections in a Security Assessment Report"
+enum SarSections {
+  "Risk Tracking Details"
+  tracking
+  "Collected During Testing"
+  collected_during_testing
+  "Mitigating Factors"
+  mitigating_factor
+}
 
-  "Appendices of a Security Assessment Report"
-  enum SarAppendices {
-    "Database Scan"
-    db_scan
-    "Web Scan"
-    web_scan
-    "Penetration Testing"
-    pen_test
-    "Manual Test"
-    manual_test
-  }
+"Appendices of a Security Assessment Report"
+enum SarAppendices {
+  "Database Scan"
+  db_scan
+  "Web Scan"
+  web_scan
+  "Penetration Testing"
+  pen_test
+  "Manual Test"
+  manual_test
+}
 
 ##### OSCAL Property
 ##
-  "Defines an attribute, characteristic, or quality of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
-  type Property implements ComplexDatatype {
-    # ComplexDatatype
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the type of the Object."
-    entity_type: String!
-    # OSCAL Property
-    "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
-    prop_name: String!
-    "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
-    ns: URL
-    "Indicates the value of the attribute, characteristic, or quality."
-    value: [String!]
-    "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
-    class: String
-  }
-    input PropertyAddInput {
-    # OSCAL Property
-    "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
-    prop_name: String!
-    "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
-    ns: URL
-    "Indicates the value of the attribute, characteristic, or quality."
-    value: [String!]
-    "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
-    class: String
-  }
+"Defines an attribute, characteristic, or quality of the containing object expressed as a namespace qualified name/value pair. The value of a property is a simple scalar value, which may be expressed as a list of values."
+type Property implements ComplexDatatype {
+  # ComplexDatatype
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the type of the Object."
+  entity_type: String!
+  # OSCAL Property
+  "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
+  prop_name: String!
+  "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
+  ns: URL
+  "Indicates the value of the attribute, characteristic, or quality."
+  value: [String!]
+  "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
+  class: String
+}
+input PropertyAddInput {
+  # OSCAL Property
+  "Identifies a textual label that uniquely identifies a specific attribute, characteristic, or quality of the property's containing object."
+  prop_name: String!
+  "Identifies a namespace qualifying the property's name. This allows different organizations to associate distinct semantics with the same name."
+  ns: URL
+  "Indicates the value of the attribute, characteristic, or quality."
+  value: [String!]
+  "Identifies a textual label that provides a sub-type or characterization of the property's name. This can be used to further distinguish or discriminate between the semantics of multiple properties of the same object with the same name and ns."
+  class: String
+}

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/sparql-query.js
@@ -39,7 +39,7 @@ const poamReducer = (item) => {
     ...(item.roles && {roles_iri: item.roles}),
     ...(item.locations && {locations_iri: item.locations}),
     ...(item.parties && {parties_iri: item.parties}),
-    ...(item.responsible_parties && {resp_parties_iri: item.responsible_parties}),
+    ...(item.responsible_parties && {responsible_parties_iri: item.responsible_parties}),
     ...(item.labels && {labels_iri: item.labels}),
     ...(item.links && {links_iri: item.links}),
     ...(item.remarks && {remarks_iri: item.remarks}),
@@ -100,7 +100,7 @@ const poamLocalDefReducer = (item) => {
     // Local Definition
     ...(item.components && {components_iri: item.components}),
     ...(item.inventory_items && {inventory_items_iri: item.inventory_items}),
-    ...(item.assessment_platforms && {assessment_platforms_iri: item.assessment_platforms}),
+    ...(item.assessment_assets && {assessment_assets_iri: item.assessment_assets}),
     ...(item.remarks && {remarks_iri: item.remarks}),
   }
 }

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/typeDefs.graphql
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/typeDefs.graphql
@@ -1,337 +1,345 @@
-  # declares the query entry-points for this type
-  extend type Query {
-    poam( id: ID ): POAM
-    poams(
-      first: Int
-      offset: Int
-      orderedBy: POAMOrdering
-      orderMode: OrderingMode
-      filters: [POAMFiltering]
-      filterMode: FilterMode
-      search: String
-    ): POAMConnection
-    poamItem( id: ID ): POAMItem
-    poamItems(
-      first: Int
-      offset: Int
-      orderedBy: POAMItemsOrdering
-      orderMode: OrderingMode
-      filters: [POAMItemsFiltering]
-      filterMode: FilterMode
-      search: String
-    ): POAMItemConnection
-  }
+# declares the query entry-points for this type
+extend type Query {
+  poam(id: ID): POAM
+  poams(
+    first: Int
+    offset: Int
+    orderedBy: POAMOrdering
+    orderMode: OrderingMode
+    filters: [POAMFiltering]
+    filterMode: FilterMode
+    search: String
+  ): POAMConnection
+  poamItem(id: ID): POAMItem
+  poamItems(
+    first: Int
+    offset: Int
+    orderedBy: POAMItemsOrdering
+    orderMode: OrderingMode
+    filters: [POAMItemsFiltering]
+    filterMode: FilterMode
+    search: String
+  ): POAMItemConnection
+}
 
-  # declares the mutation entry-points for this type
-  extend type Mutation {
-    # POAM
-    createPOAM(input: POAMAddInput): POAM
-    deletePOAM(id: ID!): String!
-    editPOAM(id: ID!, input: [EditInput]!, commitMessage: String): POAM
-    # POAM Item
-    createPOAMItem(poam: ID = "22f2ad37-4f07-5182-bf4e-59ea197a73dc", input: POAMItemAddInput): POAMItem
-    deletePOAMItem(poam: ID = "22f2ad37-4f07-5182-bf4e-59ea197a73dc", id: ID!): String!
-    editPOAMItem(id: ID!, input: [EditInput]!, commitMessage: String): POAMItem
-  }
+# declares the mutation entry-points for this type
+extend type Mutation {
+  # POAM
+  createPOAM(input: POAMAddInput): POAM
+  deletePOAM(id: ID!): String!
+  editPOAM(id: ID!, input: [EditInput]!, commitMessage: String): POAM
+  # POAM Item
+  createPOAMItem(
+    poam: ID = "22f2ad37-4f07-5182-bf4e-59ea197a73dc"
+    input: POAMItemAddInput
+  ): POAMItem
+  deletePOAMItem(
+    poam: ID = "22f2ad37-4f07-5182-bf4e-59ea197a73dc"
+    id: ID!
+  ): String!
+  editPOAMItem(id: ID!, input: [EditInput]!, commitMessage: String): POAMItem
+}
 
 ## POAM
 #
-  type POAM implements BasicObject & LifecycleObject & OscalObject &  Model {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Metadata
-    "Identifies the name given to the document."
-    name: String!
-    "Identifies the date and time the document was published."
-    published: Timestamp
-    "Identifies the date and time the document as last modified."
-    last_modified: Timestamp
-    "Identifies the current version of the document."
-    version: String!
-    "Identifies the OSCAL model version the document was authored against."
-    oscal_version: String!
-    "Identifies a list of revisions to the containing document."
-    revisions: [Revision]
-    "Identifies references to previous versions of this document."
-    document_ids: [ID]
-    "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
-    roles(first: Int, offset: Int): OscalRoleConnection
-    "Identifies one or more references to a location."
-    locations(first: Int, offset: Int): OscalLocationConnection
-    "Identifies one or more references to a responsible entity which is either a person or an organization."
-    parties(first: Int, offset: Int): OscalPartyConnection
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties(first: Int, offset: Int): OscalResponsiblePartyConnection
-    # POAM Item
-    system_id: String
-    "Identifies the identification system from which the provided identifier was assigned."
-    system_identifier_type: String!
-    "Identifies components and inventory-items to be defined within the POA&M for circumstances where no OSCAL-based SSP exists, or is not delivered with the POA&M."
-    local_definitions: POAMLocalDefinitions
-    "Identifies one or more individual observations."
-    observations(first: Int, offset: Int): ObservationConnection
-    "Identifies one or more individual observations."
-    risks(first: Int, offset: Int): RiskConnection
-    "Identifies one ore more POAM Items that bind a specific Risk to the associated Observations."
-    poam_items(first: Int, offset: Int): POAMItemConnection
-    # Backmatter
-    "Identifies one or more Resources that are associated with this POAM."
-    resources(first: Int, offset: Int): OscalResourceConnection
-  }
-
-  input POAMAddInput {
-    # Metadata
-    "Identifies the name given to the document."
-    name: String!
-    "Identifies the date and time the document was published."
-    published: Timestamp
-    "Identifies the date and time the document as last modified."
-    last_modified: Timestamp
-    "Identifies the current version of the document."
-    version: String!
-    "Identifies the OSCAL model version the document was authored against."
-    oscal_version: String!
-    "Identifies a list of revisions to the containing document."
-    revisions: [RevisionAddInput]
-    "Identifies references to previous versions of this document."
-    document_ids: [ID]
-    "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
-    roles: [OscalRoleAddInput]
-    "Identifies one or more references to a location."
-    locations: [OscalLocationAddInput]
-    "Identifies one or more references to a responsible entity which is either a person or an organization."
-    parties: [OscalPartyAddInput]
-    "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
-    responsible_parties: [OscalResponsiblePartyAddInput]
-    # POAM Item
-    system_id: String
-    "Identifies the identification system from which the provided identifier was assigned."
-    system_identifier_type: String!
-  }
-
-    # Pagination Types
-  type POAMConnection {
-    pageInfo: PageInfo!
-    edges: [POAMEdge]
-  }
-  type POAMEdge {
-    cursor: String!
-    node: POAM!
-  }
-  # Filtering Types
-  input POAMFiltering {
-    key: POAMFilter!
-    values: [String]!
-    operator: String
+type POAM implements BasicObject & LifecycleObject & OscalObject & Model {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of CyioExternalReferences, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Metadata
+  "Identifies the name given to the document."
+  name: String!
+  "Identifies the date and time the document was published."
+  published: Timestamp
+  "Identifies the date and time the document as last modified."
+  last_modified: Timestamp
+  "Identifies the current version of the document."
+  version: String!
+  "Identifies the OSCAL model version the document was authored against."
+  oscal_version: String!
+  "Identifies a list of revisions to the containing document."
+  revisions: [Revision]
+  "Identifies references to previous versions of this document."
+  document_ids: [ID]
+  "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
+  roles(first: Int, offset: Int): OscalRoleConnection
+  "Identifies one or more references to a location."
+  locations(first: Int, offset: Int): OscalLocationConnection
+  "Identifies one or more references to a responsible entity which is either a person or an organization."
+  parties(first: Int, offset: Int): OscalPartyConnection
+  "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
+  responsible_parties(first: Int, offset: Int): OscalResponsiblePartyConnection
+  # POAM Item
+  system_id: String
+  "Identifies the identification system from which the provided identifier was assigned."
+  system_identifier_type: String!
+  "Identifies components and inventory-items to be defined within the POA&M for circumstances where no OSCAL-based SSP exists, or is not delivered with the POA&M."
+  local_definitions: POAMLocalDefinitions
+  "Identifies one or more individual observations."
+  observations(first: Int, offset: Int): ObservationConnection
+  "Identifies one or more individual observations."
+  risks(first: Int, offset: Int): RiskConnection
+  "Identifies one ore more POAM Items that bind a specific Risk to the associated Observations."
+  poam_items(first: Int, offset: Int): POAMItemConnection
+  # Backmatter
+  "Identifies one or more Resources that are associated with this POAM."
+  resources(first: Int, offset: Int): OscalResourceConnection
+}
 
-  enum POAMOrdering {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "POAM ID"
-    poam_id
-    "Name"
-    name
-    "Last Modified"
-    last_modified
-    "Published"
-    published
-    "System Identifier"
-    system_id
-  }
+input POAMAddInput {
+  # Metadata
+  "Identifies the name given to the document."
+  name: String!
+  "Identifies the date and time the document was published."
+  published: Timestamp
+  "Identifies the date and time the document as last modified."
+  last_modified: Timestamp
+  "Identifies the current version of the document."
+  version: String!
+  "Identifies the OSCAL model version the document was authored against."
+  oscal_version: String!
+  "Identifies a list of revisions to the containing document."
+  revisions: [RevisionAddInput]
+  "Identifies references to previous versions of this document."
+  document_ids: [ID]
+  "Identifies one or more references to a function assumed or expected to be assumed by a party in a specific situation."
+  roles: [OscalRoleAddInput]
+  "Identifies one or more references to a location."
+  locations: [OscalLocationAddInput]
+  "Identifies one or more references to a responsible entity which is either a person or an organization."
+  parties: [OscalPartyAddInput]
+  "Identifies one or more references to a set of organizations or persons that have responsibility for performing a referenced role in the context of the containing object."
+  responsible_parties: [OscalResponsiblePartyAddInput]
+  # POAM Item
+  system_id: String
+  "Identifies the identification system from which the provided identifier was assigned."
+  system_identifier_type: String!
+}
 
-  enum POAMFilter {
-    "Created"
-    created
-    "Modified"
-    modified
-    "Label"
-    label_name
-    "POAM ID"
-    poam_id
-    "Name"
-    name
-    "Last Modified"
-    last_modified
-    "Published"
-    published
-    "System Identifier"
-    system_id
-  }
+# Pagination Types
+type POAMConnection {
+  pageInfo: PageInfo!
+  edges: [POAMEdge]
+}
+type POAMEdge {
+  cursor: String!
+  node: POAM!
+}
+# Filtering Types
+input POAMFiltering {
+  key: POAMFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
 
+enum POAMOrdering {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "POAM ID"
+  poam_id
+  "Name"
+  name
+  "Last Modified"
+  last_modified
+  "Published"
+  published
+  "System Identifier"
+  system_id
+  "Marking"
+  marking
+}
 
-  "Defines identifying information about a POAM Item"
-  type POAMItem implements BasicObject & LifecycleObject & OscalObject {
-    # BasicObject
-    "Uniquely identifies this object."
-    id: ID!
-    "Identifies the identifier defined by the standard."
-    standard_id: String!
-    "Identifies the type of the Object."
-    entity_type: String!
-    "Identifies the parent types of this object."
-    parent_types: [String]!
-    # CoreObject
-    "Indicates the date and time at which the object was originally created."
-    created: Timestamp
-    "Indicates the date and time that this particular version of the object was last modified."
-    modified: Timestamp
-    # OscalObject
-    "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
-    labels: [CyioLabel]
-    "Identifies a list of external references, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
-    links: [CyioExternalReference]
-    "Identifies one or more references to additional commentary on the Model."
-    remarks: [CyioNote]
-    "Identifies one or more relationships to other entities."
-    relationships(
-      first: Int
-      offset: Int
-      orderedBy: OscalRelationshipsOrdering
-      orderMode: OrderingMode
-      filters: [OscalRelationshipsFiltering]
-      filterMode: FilterMode
-      search: String 
-    ): OscalRelationshipConnection
-    # Finding
-    "Identifies the name for this POA&M item."
-    name: String!
-    "Identifies a human-readable description of the POA&M item."
-    description: String
-    "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
-    origins: [Origin]
-    # "Identifies an assessor's conclusions regarding the degree to which an objective is satisfied."
-    # target: FindingTarget
-    # "Identifies a reference to the implementation statement in the SSP to which this finding is related."
-    # implementation_statement: ImplementationStatement
-    "Relates the item to a set of referenced observations that were used to determine the finding."
-    related_observations(first: Int, offset: Int): ObservationConnection
-    "Relates the item to a set of referenced risks that were used to determine the finding."
-    related_risks(first: Int, offset: Int): RiskConnection
-    # POAM Item
-    "Indicates a CSP-assigned unique POA&M ID to allow for compliance with FedRAMP."
-    poam_id: String
-    # DarkLight extension to optimize ability to check to see if a specific risk has been accepted
-    "Indicates the risk has been excepted"
-    accepted_risk: Boolean
-    "Indicate the number of occurrences of the risk based on observations associated with the risk"
-    occurrences: Int
-  }
+enum POAMFilter {
+  "Created"
+  created
+  "Modified"
+  modified
+  "Label"
+  label_name
+  "POAM ID"
+  poam_id
+  "Name"
+  name
+  "Last Modified"
+  last_modified
+  "Published"
+  published
+  "System Identifier"
+  system_id
+}
 
-  input POAMItemAddInput {
-    "Identifies the name for this POA&M item."
-    name: String!
-    "Identifies a human-readable description of the POA&M item."
-    description: String
-    # POAM Item
-    "Indicates a CSP-assigned unique POA&M ID to allow for compliance with FedRAMP."
-    poam_id: String
-    # DarkLight extension to optimize ability to check to see if a specific risk has been accepted
-    "Indicates the risk has been accepted"
-    accepted_risk: Boolean
-  }
-
-  # Pagination Types
-  type POAMItemConnection {
-    pageInfo: PageInfo!
-    edges: [POAMItemEdge]
-  }
-  type POAMItemEdge {
-    cursor: String!
-    node: POAMItem!
-  }
-  # Filtering Types
-  input POAMItemsFiltering {
-    key: POAMItemsFilter!
-    values: [String]!
-    operator: String
+"Defines identifying information about a POAM Item"
+type POAMItem implements BasicObject & LifecycleObject & OscalObject {
+  # BasicObject
+  "Uniquely identifies this object."
+  id: ID!
+  "Identifies the identifier defined by the standard."
+  standard_id: String!
+  "Identifies the type of the Object."
+  entity_type: String!
+  "Identifies the parent types of this object."
+  parent_types: [String]!
+  # CoreObject
+  "Indicates the date and time at which the object was originally created."
+  created: Timestamp
+  "Indicates the date and time that this particular version of the object was last modified."
+  modified: Timestamp
+  # OscalObject
+  "Identifies a set of terms used to describe this object. The terms are user-defined or trust-group defined."
+  labels: [CyioLabel]
+  "Identifies a list of external references, each of which refers to information external to the data model. This property is used to provide one or more URLs, descriptions, or IDs to records in other systems."
+  links: [CyioExternalReference]
+  "Identifies one or more references to additional commentary on the Model."
+  remarks: [CyioNote]
+  "Identifies one or more relationships to other entities."
+  relationships(
+    first: Int
+    offset: Int
+    orderedBy: OscalRelationshipsOrdering
+    orderMode: OrderingMode
+    filters: [OscalRelationshipsFiltering]
     filterMode: FilterMode
-  }
+    search: String
+  ): OscalRelationshipConnection
+  # Finding
+  "Identifies the name for this POA&M item."
+  name: String!
+  "Identifies a human-readable description of the POA&M item."
+  description: String
+  "Identifies one or more sources of the finding, such as a tool, interviewed person, or activity."
+  origins: [Origin]
+  # "Identifies an assessor's conclusions regarding the degree to which an objective is satisfied."
+  # target: FindingTarget
+  # "Identifies a reference to the implementation statement in the SSP to which this finding is related."
+  # implementation_statement: ImplementationStatement
+  "Relates the item to a set of referenced observations that were used to determine the finding."
+  related_observations(first: Int, offset: Int): ObservationConnection
+  "Relates the item to a set of referenced risks that were used to determine the finding."
+  related_risks(first: Int, offset: Int): RiskConnection
+  # POAM Item
+  "Indicates a CSP-assigned unique POA&M ID to allow for compliance with FedRAMP."
+  poam_id: String
+  # DarkLight extension to optimize ability to check to see if a specific risk has been accepted
+  "Indicates the risk has been excepted"
+  accepted_risk: Boolean
+  "Indicate the number of occurrences of the risk based on observations associated with the risk"
+  occurrences: Int
+}
 
-  enum POAMItemsOrdering {
-    "Created"
-    created       # Created before/Created after (key: created, values: ["2021-11-10"], operator: "gt|lt")
-    "Modified"
-    modified      # Modified before/Mreated after (key: created, values: ["2021-11-10"], operator: "gt|lt")
-    "Label"
-    label_name
-    "POAM ID"
-    poam_id
-    "Name"
-    name
-    "Risk Level"
-    risk_level
-    "Risk Status"
-    risk_status
-    "Risk Response Type"
-    response_type
-    "Risk Lifecycle Phase"
-    lifecycle
-    "Risk Migitation Deadline"
-    deadline       # Deadline (key: deadline, values: ["2021-11-10"], operator: "gt|lt")
-    "Occurrences"
-    occurrences
-  }
+input POAMItemAddInput {
+  "Identifies the name for this POA&M item."
+  name: String!
+  "Identifies a human-readable description of the POA&M item."
+  description: String
+  # POAM Item
+  "Indicates a CSP-assigned unique POA&M ID to allow for compliance with FedRAMP."
+  poam_id: String
+  # DarkLight extension to optimize ability to check to see if a specific risk has been accepted
+  "Indicates the risk has been accepted"
+  accepted_risk: Boolean
+}
 
-  enum POAMItemsFilter {
-    "Created"
-    created         # Created before/Created after (key: created, values: ["2021-11-10"], operator: "gt|lt")
-    "Modified"
-    modified        # Modified before/Mreated after (key: created, values: ["2021-11-10"], operator: "gt|lt")
-    "Label"
-    label_name
-    "Risk Level"
-    risk_level      # Risk Level (key:risk_level, values: ["value1","value2"], operator: eq)
-    "Risk Status"
-    risk_status     # Risk Status (key:risk_status, values: ["value1","value2"], operator: eq)
-    "Risk Response"
-    response_type   # Risk Response (key:response_type, values: ["value1","value2"], operator: eq)
-    "Risk Lifecycle Phase"
-    lifecycle       # Risk Lifecycle (key:lifecycle, values: ["value1","value2"], operator: eq)
-    "Risk Migitation Deadline"
-    deadline        # Deadline (key: deadline, values: ["2021-11-10"], operator: "gt|lt")
-  }
+# Pagination Types
+type POAMItemConnection {
+  pageInfo: PageInfo!
+  edges: [POAMItemEdge]
+}
+type POAMItemEdge {
+  cursor: String!
+  node: POAMItem!
+}
+# Filtering Types
+input POAMItemsFiltering {
+  key: POAMItemsFilter!
+  values: [String]!
+  operator: String
+  filterMode: FilterMode
+}
+
+enum POAMItemsOrdering {
+  "Created"
+  created # Created before/Created after (key: created, values: ["2021-11-10"], operator: "gt|lt")
+  "Modified"
+  modified # Modified before/Mreated after (key: created, values: ["2021-11-10"], operator: "gt|lt")
+  "Label"
+  label_name
+  "POAM ID"
+  poam_id
+  "Name"
+  name
+  "Risk Level"
+  risk_level
+  "Risk Status"
+  risk_status
+  "Risk Response Type"
+  response_type
+  "Risk Lifecycle Phase"
+  lifecycle
+  "Risk Migitation Deadline"
+  deadline # Deadline (key: deadline, values: ["2021-11-10"], operator: "gt|lt")
+  "Occurrences"
+  occurrences
+  "Marking"
+  marking
+}
+
+enum POAMItemsFilter {
+  "Created"
+  created # Created before/Created after (key: created, values: ["2021-11-10"], operator: "gt|lt")
+  "Modified"
+  modified # Modified before/Mreated after (key: created, values: ["2021-11-10"], operator: "gt|lt")
+  "Label"
+  label_name
+  "Risk Level"
+  risk_level # Risk Level (key:risk_level, values: ["value1","value2"], operator: eq)
+  "Risk Status"
+  risk_status # Risk Status (key:risk_status, values: ["value1","value2"], operator: eq)
+  "Risk Response"
+  response_type # Risk Response (key:response_type, values: ["value1","value2"], operator: eq)
+  "Risk Lifecycle Phase"
+  lifecycle # Risk Lifecycle (key:lifecycle, values: ["value1","value2"], operator: eq)
+  "Risk Migitation Deadline"
+  deadline # Deadline (key: deadline, values: ["2021-11-10"], operator: "gt|lt")
+}
 
 ## POAM Local Definition
 #
-  type POAMLocalDefinitions {
-    components(first: Int, offset: Int): ComponentConnection
-    inventory_items(first: Int, offset: Int): InventoryItemConnection
-    assessment_assets: AssessmentAsset
-    remarks: [CyioNote]
-  }
-
+type POAMLocalDefinitions {
+  components(first: Int, offset: Int): ComponentConnection
+  inventory_items(first: Int, offset: Int): InventoryItemConnection
+  assessment_assets: AssessmentAsset
+  remarks: [CyioNote]
+}

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/risk-mappings.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/risk-mappings.js
@@ -250,6 +250,7 @@ export const riskTypeMapping = {
   "oscal-role": "OscalRole",
   "oscal-resource": "OscalResource",
   "oscal-responsible-party": "OscalResponsibleParty",
+  "oscal-responsible-role": "OscalResponsibleRole",
   "oscal-revision": "Revision",
   "oscal-task": "OscalTask",
   "oscal-user": "OscalUser",

--- a/opencti-platform/opencti-graphql/src/graphql/schema.js
+++ b/opencti-platform/opencti-graphql/src/graphql/schema.js
@@ -125,6 +125,7 @@ import poamItemResolvers from '../cyio/schema/risk-assessments/poam/resolvers/po
 import componentResolvers from '../cyio/schema/risk-assessments/component/resolvers/component.js';
 import inventoryItemResolvers from '../cyio/schema/risk-assessments/inventory-item/resolvers/inventoryItem.js';
 import assessmentAssetResolvers from '../cyio/schema/risk-assessments/assessment-common/resolvers/assessmentAsset.js';
+import oscalResponsibleRoleResolvers from '../cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleRole.js';
 // Cyio Extensions to support merged graphQL schema
 import { loadSchemaSync } from '@graphql-tools/load';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader' ;
@@ -267,6 +268,7 @@ const createSchema = () => {
       componentResolvers,
       inventoryItemResolvers,
       assessmentAssetResolvers,
+      oscalResponsibleRoleResolvers,
 ]);
 
   // load the OpenCTI and each of the Cyio GraphQL schema files


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* added support for retrieving Components and Inventory-Items from the POAM's local-definition
* added support for assessment-asset to POAM's local-definition
* added support for OscalResponsibleRole
* added support for NIST OSCAL Property objects required to support Component and Inventory-Item
* provided dynamic translation from Assets to NIST OSCAL Component/InventoryItem
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...