### PR TITLE
Ab#5491

### DIFF
--- a/opencti-platform/opencti-front/src/private/Index.js
+++ b/opencti-platform/opencti-front/src/private/Index.js
@@ -72,7 +72,7 @@ const Index = (me) => {
       });
     }
     const jwtToken = JSON.parse(atob(me.me.access_token.split('.')[1]));
-    const expiration = (jwtToken.exp * 1000) - Date.now();
+    const expiration = ((jwtToken.exp - 60) * 1000) - Date.now();
     if (expiration >= 0) {
       setInterval(() => {
         localStorage.removeItem('token');

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -98,6 +98,7 @@
     "passport-saml": "3.1.1",
     "prom-client": "^14.0.1",
     "python-shell": "3.0.0",
+    "qs": "^6.11.0",
     "ramda": "0.28.0",
     "redlock": "4.2.0",
     "remarkable-admonitions": "0.2.2",

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -15,6 +15,8 @@ import { initAdmin, login, loginFromProvider } from '../domain/user';
 import conf, { logApp } from './conf';
 import { ConfigurationError } from './errors';
 import { isNotEmptyField } from '../database/utils';
+import axios from 'axios';
+import qs from 'qs';
 
 export const empty = R.anyPass([R.isNil, R.isEmpty]);
 
@@ -103,8 +105,8 @@ const AUTH_SSO = 'SSO';
 const AUTH_FORM = 'FORM';
 
 const providers = [];
-const providerLoginHandler = (userInfo, roles, groups, done, token) => {
-  loginFromProvider(userInfo, roles, groups, token)
+const providerLoginHandler = (userInfo, roles, groups, done, token, refresh) => {
+  loginFromProvider(userInfo, roles, groups, token, refresh)
     .then((user) => {
       done(null, user);
     })
@@ -124,6 +126,42 @@ const genConfigMapper = (elements) => {
 };
 const confProviders = conf.get('providers');
 const providerKeys = Object.keys(confProviders);
+
+let oidcRefreshAxios = null;
+let oidcIssuer = null
+export const oidcRefresh = async (refreshToken) => {
+  if(oidcRefreshAxios === null) throw new Error("Unable to refresh token, OIDC not configured.")
+  try {
+    const {data} = await oidcRefreshAxios.post('/protocol/openid-connect/token',qs.stringify({
+      ...oidcRefreshAxios.defaults.data,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    }), {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    })
+    return {
+      refreshToken: data.refresh_token,
+      accessToken: data.access_token
+    }
+
+  }catch(e) {
+    logApp.error(`[OIDC] Failed to refresh token`, e.data)
+  }
+}
+
+const configureOidcRefresh = (config) => {
+  oidcIssuer = config.issuer;
+  oidcRefreshAxios = axios.create({
+    baseURL: oidcIssuer,
+    data: {
+      client_id: config.client_id,
+      client_secret: config.client_secret
+    }
+  });
+}
+
 for (let i = 0; i < providerKeys.length; i += 1) {
   const providerIdent = providerKeys[i];
   const provider = confProviders[providerIdent];
@@ -272,12 +310,13 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           // endregion
           if (!isRoleBaseAccess || rolesToAssociate.length > 0) {
             const { email, name } = userinfo;
-            providerLoginHandler({ email, name }, rolesToAssociate, groupsToAssociate, done, tokenset.access_token);
+            providerLoginHandler({ email, name }, rolesToAssociate, groupsToAssociate, done, tokenset.access_token, tokenset.refresh_token);
           } else {
             done({ message: 'Restricted access, ask your administrator' });
           }
         });
         passport.use('oic', openIDStrategy);
+        configureOidcRefresh(config);
         providers.push({ name: providerName, type: AUTH_SSO, strategy, provider: 'oic' });
       });
     }

--- a/opencti-platform/opencti-graphql/src/config/tokenManagement.js
+++ b/opencti-platform/opencti-graphql/src/config/tokenManagement.js
@@ -1,0 +1,43 @@
+import qs from 'qs';
+import axios from 'axios';
+import { logApp } from './conf';
+
+let oidcRefreshAxios = null;
+let oidcIssuer = null;
+
+export const oidcRefresh = async (refreshToken) => {
+  if (oidcRefreshAxios === null) throw new Error('Unable to refresh token, OIDC not configured.');
+  try {
+    const { data } = await oidcRefreshAxios.post(
+      '/protocol/openid-connect/token',
+      qs.stringify({
+        ...oidcRefreshAxios.defaults.data,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }
+    );
+    return {
+      refreshToken: data.refresh_token,
+      accessToken: data.access_token,
+    };
+  } catch (e) {
+    logApp.error(`[OIDC] Failed to refresh token`, e.data);
+    throw e;
+  }
+};
+
+export const configureOidcRefresh = (config) => {
+  oidcIssuer = config.issuer;
+  oidcRefreshAxios = axios.create({
+    baseURL: oidcIssuer,
+    data: {
+      client_id: config.client_id,
+      client_secret: config.client_secret,
+    },
+  });
+};

--- a/opencti-platform/opencti-graphql/src/config/tokenManagement.js
+++ b/opencti-platform/opencti-graphql/src/config/tokenManagement.js
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import axios from 'axios';
+import jwtDecode from 'jwt-decode';
 import { logApp } from './conf';
 
 let oidcRefreshAxios = null;
@@ -40,4 +41,12 @@ export const configureOidcRefresh = (config) => {
       client_secret: config.client_secret,
     },
   });
+};
+
+export const tokenExpired = (token) => {
+  const decoded = jwtDecode(token);
+  const expires = decoded.exp;
+  const nowTime = new Date();
+  const epochSec = Math.round(nowTime.getTime() / 1000) + nowTime.getTimezoneOffset() * 60;
+  return epochSec < expires + 60;
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -49,7 +49,7 @@ import {
 import { buildPagination, isEmptyField, isNotEmptyField } from '../database/utils';
 import { BYPASS, SYSTEM_USER } from '../utils/access';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
-import { oidcRefresh } from '../config/tokenManagement';
+import {oidcRefresh, tokenExpired} from '../config/tokenManagement';
 
 const BEARER = 'Bearer ';
 const BASIC = 'Basic ';
@@ -577,14 +577,6 @@ export const userRenewToken = async (user, userId) => {
   const patch = { api_token: uuid() };
   await patchAttribute(user, userId, ENTITY_TYPE_USER, patch);
   return loadById(user, userId, ENTITY_TYPE_USER);
-};
-
-export const tokenExpired = (token) => {
-  const decoded = jwtDecode(token);
-  const expires = decoded.exp;
-  const nowTime = new Date();
-  const epochSec = Math.round(nowTime.getTime() / 1000) + nowTime.getTimezoneOffset() * 60;
-  return epochSec < expires + 60;
 };
 
 const authenticateUserOIDC = async (user) => {

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -48,6 +48,8 @@ import {
 import { buildPagination, isEmptyField, isNotEmptyField } from '../database/utils';
 import { BYPASS, SYSTEM_USER } from '../utils/access';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
+import jwtDecode from 'jwt-decode';
+import {oidcRefresh} from "../config/providers";
 
 const BEARER = 'Bearer ';
 const BASIC = 'Basic ';
@@ -443,7 +445,7 @@ export const userIdDeleteRelation = async (user, userId, toId, relationshipType)
   return userDeleteRelation(user, userData, toId, relationshipType);
 };
 
-export const loginFromProvider = async (userInfo, providerRoles = [], providerGroups = [], accessToken) => {
+export const loginFromProvider = async (userInfo, providerRoles = [], providerGroups = [], accessToken, refreshToken) => {
   const { email, name: providedName, firstname, lastname } = userInfo;
   if (isEmptyField(email)) {
     throw Error('User email not provided');
@@ -459,14 +461,15 @@ export const loginFromProvider = async (userInfo, providerRoles = [], providerGr
       user_email: email.toLowerCase(),
       external: true,
       access_token: accessToken,
+      refresh_token: refreshToken
     };
     return addUser(SYSTEM_USER, newUser).then(() => {
       // After user creation, reapply login to manage roles and groups
-      return loginFromProvider(userInfo, providerRoles, providerGroups, accessToken);
+      return loginFromProvider(userInfo, providerRoles, providerGroups, accessToken, refreshToken);
     });
   }
   // Update the basic information
-  const patch = { name, firstname, lastname, external: true, access_token: accessToken };
+  const patch = { name, firstname, lastname, external: true, access_token: accessToken, refresh_token: refreshToken };
   await patchAttribute(SYSTEM_USER, user.id, ENTITY_TYPE_USER, patch);
   // Update the roles
   // If roles are specified here, that overwrite the default assignation
@@ -525,6 +528,7 @@ const buildSessionUser = (user) => {
     internal_id: user.internal_id,
     user_email: user.user_email,
     access_token: user.access_token,
+    refresh_token: user.refresh_token,
     name: user.name,
     capabilities: user.capabilities.map((c) => ({ id: c.id, internal_id: c.internal_id, name: c.name })),
     allowed_marking: user.allowed_marking.map((m) => ({
@@ -571,36 +575,63 @@ export const userRenewToken = async (user, userId) => {
 
 export const authenticateUser = async (req, user, provider) => {
   // Build the user session with only required fields
-  const sessionUser = await buildCompleteUser(user);
+  let sessionUser = await buildCompleteUser(user);
+  if(provider === 'oic') {
+    sessionUser = await authenticateUserOIDC(sessionUser);
+  }
   logAudit.info(userWithOrigin(req, user), LOGIN_ACTION, { provider });
   req.session.user = sessionUser;
   return sessionUser;
 };
 
+export const tokenExpired = (token) => {
+  const decoded = jwtDecode(token)
+  const expires = decoded.exp;
+  const now = new Date();
+  const epochSec = Math.round(now.getTime() / 1000) + (now.getTimezoneOffset() * 60);
+  return epochSec < (expires + 60);
+}
+
+const authenticateUserOIDC = async (user) => {
+  const token = user.access_token
+  if(tokenExpired(token)) {
+    const {accessToken, refreshToken} = await oidcRefresh(user.refresh_token)
+    const patch = {
+      access_token: accessToken,
+      refresh_token: refreshToken
+    }
+    const {element: updatedUser} = await patchAttribute(SYSTEM_USER, user.id, ENTITY_TYPE_USER, patch)
+    return buildCompleteUser(updatedUser)
+  }
+  return user
+}
+
 export const authenticateUserFromRequest = async (req) => {
   const auth = req?.session?.user;
   if (auth) {
-    // User already identified
-    return auth;
+    // User already identified, check token
+    if(auth.access_token) {
+      return await authenticateUser(req, auth, 'Bearer')
+    }
   }
   // If user not identified, try to extract token from bearer
   let loginProvider = 'Bearer';
-  let tokenUUID = extractTokenFromBearer(req?.headers.authorization);
+  let authToken = extractTokenFromBearer(req?.headers.authorization);
   // If no bearer specified, try with basic auth
-  if (!tokenUUID) {
+  if (!authToken) {
     loginProvider = 'BasicAuth';
-    tokenUUID = await extractTokenFromBasicAuth(req?.headers.authorization);
+    authToken = await extractTokenFromBasicAuth(req?.headers.authorization);
   }
   // Get user from the token if found
-  if (tokenUUID) {
+  if (authToken) {
     try {
-      const user = await resolveUserByToken(tokenUUID);
+      const user = await resolveUserByToken(authToken);
       if (req && user) {
         await authenticateUser(req, user, loginProvider);
       }
       return user;
     } catch (err) {
-      logApp.error(`[CYIO] Authentication error ${tokenUUID}`, { error: err });
+      logApp.error(`[CYIO] Authentication error ${authToken}`, { error: err });
     }
   }
   return undefined;
@@ -628,6 +659,7 @@ export const initAdmin = async (email, password, tokenValue) => {
       description: 'Principal admin account',
       api_token: tokenValue,
       access_token: null,
+      refresh_token: null,
       password,
     };
     await addUser(SYSTEM_USER, userToCreate);

--- a/opencti-platform/opencti-graphql/src/schema/internalObject.js
+++ b/opencti-platform/opencti-graphql/src/schema/internalObject.js
@@ -108,6 +108,7 @@ export const internalObjectsAttributes = {
     'firstname',
     'lastname',
     'access_token',
+    'refresh_token',
     'theme',
     'language',
     'external',

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -11094,10 +11094,12 @@ chromedriver@latest:
     passport-google-oauth: 2.0.0
     passport-ldapauth: 3.0.1
     passport-local: 1.0.0
+    passport-oauth2-refresh: ^2.1.0
     passport-saml: 3.1.1
     prettier: 2.3.2
     prom-client: ^14.0.1
     python-shell: 3.0.0
+    qs: ^6.11.0
     ramda: 0.28.0
     redlock: 4.2.0
     remarkable-admonitions: 0.2.2
@@ -11421,6 +11423,13 @@ chromedriver@latest:
     passport-strategy: 1.x.x
     utils-merge: 1.x.x
   checksum: b38444da71bf3468a53599d908b45e4043c7dd04cce0ded3398a91f161ce076c5973f42ddad47e5012f8b1cccea71b60890b35560491921d0858c36b364ac471
+  languageName: node
+  linkType: hard
+
+"passport-oauth2-refresh@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "passport-oauth2-refresh@npm:2.1.0"
+  checksum: beb140862b665c920ba36450ca9c3e1fa18a9d3214971caec10e6100b04523c71ba821d56a8fb9a3d17707902fcd6faf471141dd346debce324b1112fab47bfa
   languageName: node
   linkType: hard
 
@@ -11818,6 +11827,15 @@ chromedriver@latest:
   version: 6.7.0
   resolution: "qs@npm:6.7.0"
   checksum: dfd5f6adef50e36e908cfa70a6233871b5afe66fbaca37ecc1da352ba29eb2151a3797991948f158bb37fccde51bd57845cb619a8035287bfc24e4591172c347
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.11.0":
+  version: 6.11.0
+  resolution: "qs@npm:6.11.0"
+  dependencies:
+    side-channel: ^1.0.4
+  checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the ability for the graphql server to automatically refresh a users access token. It adds the refresh_token property to the user schema. 

When a user first logs into OCTI, the token set is saved to the user entity. All subsequent requests will then check the access token of the user and validate the expiration. If the token is within one minute of being expired, the token is refreshed using the refresh token. The user entity is updated with the new token set.