### PR TITLE
AB#5695 Updated all edit operations to detect whether input is suppli…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/asset-common/resolvers.js
@@ -493,8 +493,11 @@ const assetCommonResolvers = {
       return id;
     },
     editAssetLocation: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
@@ -507,11 +510,20 @@ const assetCommonResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
       const query = updateQuery(
           `http://darklight.ai/ns/common#CivicLocation-${id}`,
           "http://darklight.ai/ns/common#CivicLocation",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/resolvers.js
@@ -425,11 +425,15 @@ const computingDeviceResolvers = {
       return id;
     },
     editComputingDeviceAsset: async (_, { id, input }, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectComputingDeviceQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -439,12 +443,21 @@ const computingDeviceResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
 
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
+      
       const query = updateQuery(
         `http://scap.nist.gov/ns/asset-identification#ComputingDevice-${id}`,
         "http://scap.nist.gov/ns/asset-identification#ComputingDevice",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/resolvers.js
@@ -435,6 +435,9 @@ const hardwareResolvers = {
       return id;
     },
     editHardwareAsset: async (_, { id, input }, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
       let editSelect = ['id','modified'];
       for (let editItem of input) {
@@ -448,6 +451,7 @@ const hardwareResolvers = {
         singularizeSchema
       });
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+      
       // determine operation, if missing
       for (let editItem of input) {
         if (editItem.operation !== undefined) continue;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/resolvers.js
@@ -136,7 +136,7 @@ const networkResolvers = {
     },
     networkAsset: async (_, {id}, {dbName, dataSources, selectMap}) => {
       const sparqlQuery = selectNetworkQuery(id, selectMap.getNode("networkAsset"));
-      var reducer = getReducer('NETWORK')
+      let reducer = getReducer('NETWORK');
       const response = await dataSources.Stardog.queryById({
         dbName,
         sparqlQuery,
@@ -335,6 +335,9 @@ const networkResolvers = {
       return id;
     },
     editNetworkAsset: async (_, { id, input }, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
       let editSelect = ['id','modified'];
       for (let editItem of input) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/network/sparql-query.js
@@ -154,6 +154,7 @@ export function getSelectSparqlQuery(type, select, id, args, ) {
   // console.log(`[INFO] Query = ${sparqlQuery}`)
   return sparqlQuery ;
 }
+
 export const insertQuery = (propValues) => {
   const id_material = {
     ...(propValues.network_name && { "network_name": propValues.network_name}),
@@ -274,6 +275,7 @@ export const selectNetworkByIriQuery = (iri, select) => {
 export const selectAllNetworks = (select, args) => {
   if (select === undefined || select === null) select = Object.keys(networkPredicateMap);
   if (!select.includes('id')) select.push('id');
+  if (!select.includes('network_id')) select.push('network_id');
 
   if (args !== undefined ) {
     if ( args.filters !== undefined ) {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/activity.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/activity.js
@@ -389,8 +389,11 @@ const activityResolvers = {
       return id;
     },
     editActivity: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
@@ -403,11 +406,20 @@ const activityResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Activity-${id}`,
@@ -566,11 +578,15 @@ const activityResolvers = {
       return id;
     },
     editAssociatedActivity: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectAssociatedActivityQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -580,11 +596,20 @@ const activityResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#AssociatedActivity-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/actor.js
@@ -296,11 +296,15 @@ const actorResolvers = {
       return id;
     },
     editActor: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectActorQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -310,11 +314,20 @@ const actorResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Actor-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/characterization.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/characterization.js
@@ -469,11 +469,15 @@ const characterizationResolvers = {
       return id;
     },
     editCharacterization: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectCharacterizationQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -483,11 +487,20 @@ const characterizationResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Characterization-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/evidence.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/evidence.js
@@ -248,11 +248,15 @@ const evidenceResolvers = {
       return id;
     },
     editEvidence: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectEvidenceQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -262,11 +266,20 @@ const evidenceResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Evidence-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/logEntry.js
@@ -538,11 +538,15 @@ const logEntryResolvers = {
       return id;
     },
     editRiskLogEntry: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectRiskLogEntryQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -552,11 +556,20 @@ const logEntryResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#RiskLogEntry-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/mitigatingFactor.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/mitigatingFactor.js
@@ -304,11 +304,15 @@ const mitigatingFactorResolvers = {
       return id;
     },
     editMitigatingFactor: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectMitigatingFactorQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -318,11 +322,20 @@ const mitigatingFactorResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#MitigatingFactor-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/observation.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/observation.js
@@ -387,11 +387,15 @@ const observationResolvers = {
       return id;
     },
     editObservation: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectObservationQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -401,11 +405,20 @@ const observationResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Observation-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/origin.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/origin.js
@@ -344,11 +344,15 @@ const originResolvers = {
       return id;
     },
     editOrigin: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectOriginQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -358,11 +362,20 @@ const originResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Origin-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/oscalTask.js
@@ -448,11 +448,15 @@ const oscalTaskResolvers = {
       return id;
     },
     editOscalTask: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectOscalTaskQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -462,11 +466,20 @@ const oscalTaskResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Task-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/requiredAsset.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/requiredAsset.js
@@ -394,11 +394,15 @@ const requiredAssetResolvers = {
     editRequiredAsset: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
       let targetIri, relationshipQuery, query;
 
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
       let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       query = selectRequiredAssetQuery(id, editSelect);
       const response = await dataSources.Stardog.queryById({
         dbName,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/risk.js
@@ -477,11 +477,15 @@ const riskResolvers = {
       return id;
     },
     editRisk: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectRiskQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -491,11 +495,15 @@ const riskResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
 
       // Handle 'dynamic' property editing separately
       for (let editItem of input) {
@@ -538,6 +546,11 @@ const riskResolvers = {
         }
       }
 
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
+      
       if (input.length > 0 ) {
         const query = updateQuery(
           `http://csrc.nist.gov/ns/oscal/assessment/common#Risk-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/riskResponse.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/riskResponse.js
@@ -520,6 +520,39 @@ const riskResponseResolvers = {
       return id;
     },
     editRiskResponse: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
+      // check that the object to be edited exists with the predicates - only get the minimum of data
+      let editSelect = ['id','modified'];
+      for (let editItem of input) {
+        editSelect.push(editItem.key);
+      }
+
+      const sparqlQuery = selectRiskResponseQuery(id, editSelect );
+      let response = await dataSources.Stardog.queryById({
+        dbName,
+        sparqlQuery,
+        queryId: "Select Risk Response",
+        singularizeSchema
+      });
+      if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
+
+      // determine operation, if missing
+      for (let editItem of input) {
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
+      }
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
+      
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#RiskResponse-${id}`,
         "http://csrc.nist.gov/ns/oscal/assessment/common#RiskResponse",

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/subject.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/subject.js
@@ -396,11 +396,15 @@ const subjectResolvers = {
       return id;
     },
     editSubject: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectSubjectQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -410,11 +414,20 @@ const subjectResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/assessment/common#Subject-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalLocation.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalLocation.js
@@ -353,11 +353,15 @@ const oscalLocationResolvers = {
       return id;
     },
     editOscalLocation: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectLocationQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -367,11 +371,20 @@ const oscalLocationResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#Location-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleParty.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalResponsibleParty.js
@@ -313,11 +313,15 @@ const responsiblePartyResolvers = {
       return id;
     },
     editOscalResponsibleParty: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectResponsiblePartyQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -327,11 +331,20 @@ const responsiblePartyResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#ResponsibleParty-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalRole.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/oscal-common/resolvers/oscalRole.js
@@ -262,11 +262,15 @@ const oscalRoleResolvers = {
       return id;
     },
     editOscalRole: async (_, { id, input }, { dbName, dataSources, selectMap }) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectRoleQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -276,11 +280,20 @@ const oscalRoleResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#Role-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poam.js
@@ -307,11 +307,15 @@ const poamResolvers = {
       return id;
     },
     editPOAM: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectPOAMQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -321,11 +325,20 @@ const poamResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/common#POAM-${id}`,

--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poamItem.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/poam/resolvers/poamItem.js
@@ -225,11 +225,15 @@ const poamItemResolvers = {
       return id;
     },
     editPOAMItem: async (_, {id, input}, {dbName, dataSources, selectMap}) => {
+      // make sure there is input data containing what is to be edited
+      if (input === undefined || input.length === 0) throw new UserInputError(`No input data was supplied`);
+
       // check that the object to be edited exists with the predicates - only get the minimum of data
-      let editSelect = ['id'];
+      let editSelect = ['id','modified'];
       for (let editItem of input) {
         editSelect.push(editItem.key);
       }
+
       const sparqlQuery = selectPOAMItemQuery(id, editSelect );
       let response = await dataSources.Stardog.queryById({
         dbName,
@@ -239,11 +243,20 @@ const poamItemResolvers = {
       })
       if (response.length === 0) throw new UserInputError(`Entity does not exist with ID ${id}`);
 
-      // TODO: WORKAROUND to handle UI where it DOES NOT provide an explicit operation
+      // determine operation, if missing
       for (let editItem of input) {
-        if (!response[0].hasOwnProperty(editItem.key)) editItem.operation = 'add';
+        if (editItem.operation !== undefined) continue;
+        if (!response[0].hasOwnProperty(editItem.key)) {
+          editItem.operation = 'add';
+        } else {
+          editItem.operation = 'replace';
+        }
       }
-      // END WORKAROUND
+
+      // Push an edit to update the modified time of the object
+      const timestamp = new Date().toISOString();
+      let update = {key: "modified", value:[`${timestamp}`], operation: "replace"}
+      input.push(update);
 
       const query = updateQuery(
         `http://csrc.nist.gov/ns/oscal/poam#Item-${id}`,


### PR DESCRIPTION
…ed and also update to modified property each time an item is editedited

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...