### PR TITLE
Adding the version to the left nav bar when running in staging or dev…

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.js
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import { assoc, compose } from 'ramda';
 import { withStyles, withTheme } from '@material-ui/core/styles';
+import graphql from 'babel-plugin-relay/macro';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -15,6 +16,7 @@ import {
   Language,
 } from '@material-ui/icons';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
+import UpdateIcon from '@material-ui/icons/Update';
 import PersonIcon from '@material-ui/icons/Person';
 import LocationCityIcon from '@material-ui/icons/LocationCity';
 import {
@@ -40,6 +42,7 @@ import UserPreferencesModal from './UserPreferencesModal';
 import FeatureFlag from '../../../components/feature/FeatureFlag';
 import { toastGenericError } from '../../../utils/bakedToast';
 import logo from '../../../resources/images/logo-mark.png';
+import { QueryRenderer } from '../../../relay/environment';
 
 const styles = (theme) => ({
   drawerOpen: {
@@ -153,6 +156,14 @@ const styles = (theme) => ({
     },
   },
 });
+
+const leftBarVersionQuery = graphql`
+  query LeftBarVersionQuery {
+    about {
+      version
+    }
+  }
+`;
 
 const LeftBar = ({
   t, location, classes, clientId, history, setClientId, theme, drawerValue,
@@ -375,6 +386,31 @@ const LeftBar = ({
             </MenuList>
           <div className={classes.bottomNavigation}>
             <MenuList component="nav" classes={{ root: classes.menuList }}>
+              <QueryRenderer
+                query={leftBarVersionQuery}
+                render={({ props: about }) => {
+                  if (about) {
+                    const { version } = about.about;
+                    if (version.includes('-')) {
+                      return (
+                        <MenuItem
+                          disabled="true"
+                          dense={false}
+                          classes={{ root: openDrawer ? classes.menuItem : classes.menuItemClose }}
+                        >
+                          <ListItemIcon style={{ minWidth: 35 }}>
+                            <UpdateIcon />
+                          </ListItemIcon>
+                          <ListItemText
+                            primary={version}
+                            className={!openDrawer && classes.hideText} />
+                        </MenuItem>
+                      );
+                    }
+                  }
+                  return '';
+                }}
+              />
               <MenuItem
                 // component={Link}
                 // to="/dashboard/profile"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added the current running version of the server to the left navbar when the version contains a dash, thus should only render when running in staging and develop. Production should not have this visual rendered to the client

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...