### PR TITLE
AB#5968 - fix translation in edit where asset_type value contains '_'…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/computing-device/sparql-query.js
@@ -128,6 +128,7 @@ export const computingDeviceAssetReducer = (item) => {
       item.asset_type = 'computing-device';
       item.object_type = 'computing-device';
     } else {
+      if (item.asset_type.includes('_')) item.asset_type = item.asset_type.replace(/_/g, '-');
       item.object_type = item.asset_type;
     }
   } else {

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/resolvers.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/resolvers.js
@@ -96,6 +96,8 @@ const hardwareResolvers = {
             continue;
           }
 
+          if (hardware.asset_type)
+
           // skip down past the offset
           if (offset) {
             offset--
@@ -491,6 +493,11 @@ const hardwareResolvers = {
         let relationshipQuery, queryDetails;
         for (value of editItem.value) {
           switch(editItem.key) {
+            case 'asset_type':
+              isId = false;
+              if (value.includes('_')) value = value.replace(/_/g, '-');
+              editItem.value[0] = value;
+              break;
             case 'connected_to_network':
               objType = 'network';
               break;

--- a/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/assets/hardware/sparql-query.js
@@ -43,6 +43,7 @@ const hardwareAssetReducer = (item) => {
       item.asset_type = 'computing-device';
       item.object_type = 'computing-device';
     } else {
+      if (item.asset_type.includes('_')) item.asset_type = item.asset_type.replace(/_/g, '-');
       item.object_type = item.asset_type;
     }
   } else {
@@ -122,6 +123,11 @@ export const insertHardwareQuery = (propValues) => {
     if (propValues.description.includes('\n')) propValues.description = propValues.description.replace(/\n/g, '\\n');
     if (propValues.description.includes('\"')) propValues.description = propValues.description.replace(/\"/g, '\\"');
     if (propValues.description.includes("\'")) propValues.description = propValues.description.replace(/\'/g, "\\'");
+  }
+
+  // Fix '_' to '-' in asset_type
+  if (propValues.asset_type !== undefined) {
+    if (propValues.asset_type.includes('_')) propValues.asset_type = propValues.asset_type.replace(/_/g, '-');
   }
 
   const iri = `<http://scap.nist.gov/ns/asset-identification#Hardware-${id}>`;


### PR DESCRIPTION
… instead of '-'

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...