### PR TITLE
Force entity_type on the stack of fields to return for a RiskResponse…

### DIFF
--- a/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
+++ b/opencti-platform/opencti-graphql/src/cyio/schema/risk-assessments/assessment-common/resolvers/sparql-query.js
@@ -2737,16 +2737,16 @@ export const selectAllOrigins = (select, args, parent) => {
   // add constraint clause to limit to those that are referenced by the specified object
   if (parent !== undefined && parent.iri !== undefined) {
     let classTypeIri;
-    if (parent.entity_type === 'characterization') {
+    if (parent.entity_type === 'characterization' || parent.iri.includes('Characterization')) {
       classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#Characterization>';
     }
-    if (parent.entity_type === 'observation') {
+    if (parent.entity_type === 'observation' || parent.iri.includes('Observation')) {
       classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#Observation>';
     }
-    if (parent.entity_type === 'risk') {
+    if (parent.entity_type === 'risk' || parent.iri.includes('Risk')) {
       classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#Risk>';
     }
-    if (parent.entity_type === 'risk-response') {
+    if (parent.entity_type === 'risk-response' || parent.iri.includes('RiskResponse')) {
       classTypeIri = '<http://csrc.nist.gov/ns/oscal/assessment/common#RiskResponse>';
     }
     // define a constraint to limit retrieval to only those referenced by the parent
@@ -3674,7 +3674,9 @@ export const selectRiskResponseQuery = (id, select) => {
 export const selectRiskResponseByIriQuery = (iri, select) => {
   if (!iri.startsWith('<')) iri = `<${iri}>`;
   if (select === undefined || select === null) select = Object.keys(riskResponsePredicateMap);
-
+  if (!select.includes('id')) select.push('id');
+  if (!select.includes('entity_type')) select.push('entity_type');
+  
   // extension properties
   if (select.includes('props')) {
     if (!select.includes('response_type')) select.push('response_type');


### PR DESCRIPTION
… even if not asked for by user

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...